### PR TITLE
feat: dynamic server version and --version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 *.log
+dist/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Add to your Claude Desktop configuration file:
 }
 ```
 
+## Checking Your Version
+
+```bash
+npx @xano/developer-mcp --version
+```
+
+If installed from source:
+
+```bash
+node dist/index.js --version
+```
+
 ## Installation from Source
 
 ### Prerequisites

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,6 +11,12 @@ import { getSchemeFromContent } from "@xano/xanoscript-language-server/utils.js"
 import { generateInitWorkspaceTemplate } from "./templates/init-workspace.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
+const SERVER_VERSION = pkg.version;
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+    console.log(SERVER_VERSION);
+    process.exit(0);
+}
 const XANOSCRIPT_DOCS_V2 = {
     readme: {
         file: "README.md",
@@ -357,7 +363,7 @@ function generateInitWorkspaceDoc() {
 // =============================================================================
 const server = new Server({
     name: "xano-developer-mcp",
-    version: "1.0.0",
+    version: SERVER_VERSION,
     description: "MCP server for Xano Headless API documentation and XanoScript code validation",
 }, {
     capabilities: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.1",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.1",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "MCP server for Xano Headless API documentation and XanoScript code validation",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,14 @@ import { generateInitWorkspaceTemplate } from "./templates/init-workspace.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
+const SERVER_VERSION: string = pkg.version;
+
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  console.log(SERVER_VERSION);
+  process.exit(0);
+}
+
 // =============================================================================
 // XanoScript Documentation v2 Configuration
 // =============================================================================
@@ -435,7 +443,7 @@ function generateInitWorkspaceDoc(): string {
 const server = new Server(
   {
     name: "xano-developer-mcp",
-    version: "1.0.0",
+    version: SERVER_VERSION,
     description:
       "MCP server for Xano Headless API documentation and XanoScript code validation",
   },


### PR DESCRIPTION
## Summary
- Read server version dynamically from `package.json` instead of hardcoding `"1.0.0"`
- Add `--version` / `-v` CLI flag to print the current version and exit
- Add `dist/` to `.gitignore` to keep build artifacts out of the repo

## Test plan
- [ ] Run `npx tsx src/index.ts --version` and verify it prints the version from package.json
- [ ] Run `npx tsx src/index.ts -v` and verify same behavior
- [ ] Verify MCP server still starts normally without the flag
- [ ] Verify `dist/` is no longer tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)