### PR TITLE
docs: add early return examples and strlen filter reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/cheatsheet.md
+++ b/src/xanoscript_docs/cheatsheet.md
@@ -153,6 +153,7 @@ $text|to_upper                // Uppercase
 $text|substr:0:10             // Substring
 $text|split:","               // Split to array
 $text|contains:"x"            // Check contains → bool
+$text|strlen                  // Length of a string
 
 // Array
 $arr|first                    // First element

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -88,6 +88,40 @@ conditional {
 }
 ```
 
+### Early Return
+
+Stop execution and return a value immediately. Useful for guard clauses and skipping unnecessary work.
+
+```xs
+// Guard clause - return early if condition is met
+conditional {
+  if ($input.skip) {
+    return { value = null }
+  }
+}
+
+// Return early with a value
+conditional {
+  if ($input.use_cache && $cached_result != null) {
+    return { value = $cached_result }
+  }
+}
+
+// Short-circuit with a successful response
+db.get "order" {
+  field_name = "id"
+  field_value = $input.order_id
+} as $order
+
+conditional {
+  if ($order.status == "completed") {
+    return { value = $order }
+  }
+}
+
+// Continue with expensive processing for non-completed orders...
+```
+
 ### API Request with Error Handling
 ```xs
 api.request {


### PR DESCRIPTION
Add early return section to quickstart guide with guard clause, caching, and short-circuit examples. Add strlen filter to cheatsheet string section. Bump version to 1.0.40.