### PR TITLE
Remove run_api_docs module, improve tool descriptions and docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -140,7 +140,7 @@ var $total {
 ### Filters (Pipe Syntax)
 
 ```xs
-$value|trim|lower                    // Chain filters
+$value|trim|to_lower                 // Chain filters
 $input.name|strlen                   // Get length
 $array|first                         // First element
 ($a + $b)|round:2                    // Math with precision

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -221,7 +221,7 @@ The most common filters at a glance:
 | Filter | Example | Result |
 |--------|---------|--------|
 | `trim` | `" hello "|trim` | `"hello"` |
-| `lower` | `"HELLO"|lower` | `"hello"` |
+| `to_lower` | `"HELLO"|to_lower` | `"hello"` |
 | `first` | `[1,2,3]|first` | `1` |
 | `count` | `[1,2,3]|count` | `3` |
 | `to_int` | `"42"|to_int` | `42` |

--- a/src/xanoscript_docs/streaming.md
+++ b/src/xanoscript_docs/streaming.md
@@ -257,7 +257,7 @@ function "import_large_csv" {
             db.add "record" {
               data = {
                 name: $row.name|trim,
-                email: $row.email|trim|lower,
+                email: $row.email|trim|to_lower,
                 created_at: now
               }
             }


### PR DESCRIPTION
## Summary
- Removed the `run_api_docs` module and associated tools/tests
- Improved tool descriptions for `validate_xanoscript` and `xanoscript_docs`
- Added Claude skill for XanoScript docs expertise
- Fixed variable filter examples to use `|to_lower` instead of `|lower` (which is an input block filter only)
- Version bump to 1.0.43

## Test plan
- [ ] Verify `npm run build` succeeds without the removed `run_api_docs` module
- [ ] Verify remaining MCP tools (`xanoscript_docs`, `validate_xanoscript`, `cli_docs`, `meta_api_docs`) work correctly
- [ ] Confirm doc examples correctly distinguish `|lower` (input filter) from `|to_lower` (variable pipe filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)