### PR TITLE
docs: add foreach loop index tracking example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/functions.md
+++ b/src/xanoscript_docs/functions.md
@@ -138,10 +138,15 @@ stack {
     }
   }
 
-  // Foreach (array iteration)
+  // Foreach (array iteration) - no built-in index; count manually if needed
+  var $index {
+    value = 0
+  }
   foreach ($input.items) {
     each as $item {
       debug.log { value = $item.name }
+      debug.log { value = $index }
+      math.add $index { value = 1 }
     }
   }
 


### PR DESCRIPTION
## Summary
- Add example showing how to manually track an index variable in `foreach` loops, since XanoScript has no built-in loop index
- Bump version to 1.0.44

## Test plan
- [ ] Verify the `foreach` index example in `functions.md` is accurate and renders correctly
- [ ] Confirm version bump in `package.json` is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)