### PR TITLE
docs: expand filter precedence, slice semantics, array access, unit test scope, and file conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -611,6 +611,28 @@ stack {
 }
 ```
 
+### 13. Multiple constructs in one file
+Each `.xs` file must contain exactly **one** construct. Placing two constructs in the same file causes a parse error.
+
+```xs
+// ❌ Wrong - two constructs in one file
+function "helper_a" {
+  stack { ... }
+  response = $result
+}
+
+function "helper_b" {
+  stack { ... }
+  response = $result
+}
+```
+
+```
+// ✅ Correct - one construct per file
+// function/helper_a.xs  → contains only "helper_a"
+// function/helper_b.xs  → contains only "helper_b"
+```
+
 ---
 
 ## Related Topics


### PR DESCRIPTION
## Summary

- **Filter precedence & parentheses** (`syntax.md`): Replaced the narrow "String Concatenation with Filters" section with a comprehensive "Parentheses and Filter Precedence" section. Explains why `$arr|count > 3` is invalid (filter grabs the operator as its argument), shows the broken patterns, and gives the corrected forms with a rule-of-thumb summary.
- **Slice semantics** (`syntax.md`): Updated the `slice` table row to show `offset 1, length 2` so `offset:length` semantics are explicit at the point of use.
- **Array element access** (`syntax.md`): Added `### Array Element Access: |get vs |slice` subsection with a comparison table and code example that highlights the `offset:length` (not `start:end`) gotcha.
- **Unit test scope limitations** (`unit-testing.md`): Added a "Scope Limitations" section clarifying that tests can only access `$response`, not intermediate stack variables or variables from called functions. Includes the workaround (expose intermediates through the response object).
- **One construct per file** (`quickstart.md`): Added Common Mistake #13 showing that multiple constructs in a single `.xs` file causes a parse error.

## Test plan

- [ ] Review each doc section for accuracy against XanoScript behavior
- [ ] Verify the filter precedence examples match parser behavior
- [ ] Confirm slice offset:length examples are correct (`|slice:1:2` on `[1,2,3,4]` → `[2,3]`)
- [ ] Confirm `|get:N` is 0-based index access

🤖 Generated with [Claude Code](https://claude.com/claude-code)