### PR TITLE
docs: add $index to reserved variable names

### DIFF
--- a/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
+++ b/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
@@ -361,7 +361,7 @@ These appear frequently in examples:
 - `$result` — accumulator in reduce operations
 - `$response` — endpoint response
 - `$output` — function output
-- `$index` - Current iteration index in for loops
+- `$index` - reserved
 
 ## Complete Topic Registry
 

--- a/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
+++ b/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
@@ -361,6 +361,7 @@ These appear frequently in examples:
 - `$result` — accumulator in reduce operations
 - `$response` — endpoint response
 - `$output` — function output
+- `$index` - Current iteration index in for loops
 
 ## Complete Topic Registry
 

--- a/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
+++ b/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
@@ -232,8 +232,8 @@ foreach ($items) {
 
 // For (iterate N times)
 for (10) {
-  each as $index {
-    debug.log { value = $index }
+  each as $idx {
+    debug.log { value = $idx }
   }
 }
 

--- a/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
+++ b/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
@@ -99,7 +99,7 @@ text[1:10] tags             // Array size constraints
 
 ### Reserved Names
 
-Cannot use as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`
+Cannot use as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`
 
 ## Operators
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -95,6 +95,7 @@ const RESERVED_VARIABLES = [
   "$response",
   "$output",
   "$input",
+  "$index",
   "$auth",
   "$env",
   "$db",

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -111,7 +111,7 @@ $db.table.field     // Database field reference (in queries)
 $this               // Current item in loops/maps
 ```
 
-**Reserved Variables:** The following cannot be used as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`.
+**Reserved Variables:** The following cannot be used as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`.
 
 ### Type Names
 

--- a/src/xanoscript_docs/cheatsheet.md
+++ b/src/xanoscript_docs/cheatsheet.md
@@ -63,8 +63,8 @@ foreach ($input.items) {
 
 // For loop (iterate N times)
 for (10) {
-  each as $index {
-    debug.log { value = $index }
+  each as $idx {
+    debug.log { value = $idx }
   }
 }
 

--- a/src/xanoscript_docs/cheatsheet.md
+++ b/src/xanoscript_docs/cheatsheet.md
@@ -249,7 +249,7 @@ var $msg { value = ($status|to_text) ~ ": " ~ ($data|json_encode) }
 
 ## Reserved Variables (Cannot Use)
 
-`$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`
+`$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`
 
 ## Input Block Syntax
 

--- a/src/xanoscript_docs/functions.md
+++ b/src/xanoscript_docs/functions.md
@@ -143,14 +143,14 @@ stack {
   }
 
   // Foreach (array iteration) - no built-in index; count manually if needed
-  var $index {
+  var $idx {
     value = 0
   }
   foreach ($input.items) {
     each as $item {
       debug.log { value = $item.name }
-      debug.log { value = $index }
-      math.add $index { value = 1 }
+      debug.log { value = $idx }
+      math.add $idx { value = 1 }
     }
   }
 
@@ -441,21 +441,6 @@ foreach ($items) {
     }
 
     // Process item
-  }
-}
-```
-
-### Loop with Index
-
-```xs
-foreach ($items) {
-  each as $item, $index {
-    db.add "item" {
-      data = {
-        value: $item,
-        position: $index
-      }
-    }
   }
 }
 ```

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -24,6 +24,7 @@ These variable names are reserved and cannot be used:
 | `$db` | Database table reference for queries |
 | `$this` | Current context reference |
 | `$result` | Used in reduce operations |
+| `$index` | Current iteration index in for loops |
 
 ```xs
 // ❌ Wrong - using reserved variable name

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -24,7 +24,7 @@ These variable names are reserved and cannot be used:
 | `$db` | Database table reference for queries |
 | `$this` | Current context reference |
 | `$result` | Used in reduce operations |
-| `$index` | Current iteration index in for loops |
+| `$index` | Reserved for some array operations |
 
 ```xs
 // ❌ Wrong - using reserved variable name


### PR DESCRIPTION
## Summary

- Adds `$index` to the reserved variable names list in all documentation files (`README.md`, `cheatsheet.md`, `quickstart.md`) and the skill reference files
- Adds `$index` to `RESERVED_VARIABLES` in the XanoScript validator (`validate_xanoscript.ts`) so it is enforced at validation time
- Bumps package version to `1.0.51`

## Test plan

- [ ] Verify `$index` appears in reserved names across all doc topics
- [ ] Verify validator rejects `var $index { ... }` as a standalone variable declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)