### PR TITLE
docs: clarify $input prefix required, $var prefix optional for stack variables

### DIFF
--- a/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
+++ b/.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md
@@ -88,14 +88,44 @@ text[1:10] tags             // Array size constraints
 
 | Pattern | Description | Example |
 |---------|-------------|---------|
-| `$input.field` | Input parameters | `$input.name` |
-| `$var.field` | Stack variables | `$var.total` |
+| `$input.field` | Input parameters — **prefix required** | `$input.name` |
+| `$var.field` or `$field` | Stack variables — prefix is optional | `$var.total` or `$total` |
 | `$auth.id` | Authenticated user | `$auth.id`, `$auth.role` |
 | `$env.NAME` | Environment variables | `$env.API_KEY` |
 | `$db.table.field` | DB field reference (queries) | `$db.user.email` |
 | `$this` | Current item in loops/maps | `$this.name` |
 | `$result` | Accumulator in reduce | `$result + $$` |
 | `$$` | Shorthand for current item in filter expressions | `$items\|map:$$.name` |
+
+### Input vs. Variable Access (Critical Distinction)
+
+Inputs and stack variables have different access rules:
+
+- **Inputs** declared in the `input {}` block **must always use `$input.fieldname`**. There is no shorthand.
+- **Stack variables** declared with `var` can be accessed as `$var.fieldname` or just `$fieldname` — they are identical.
+
+```xs
+// Declared in input block
+input {
+  text name
+  int age
+}
+
+// ❌ Wrong — inputs cannot be referenced as bare variables
+var $greeting { value = "Hello, " ~ $name }   // $name is undefined
+
+// ✅ Correct — inputs require $input prefix
+var $greeting { value = "Hello, " ~ $input.name }
+```
+
+```xs
+// Declared as a stack variable
+var $total { value = 42 }
+
+// ✅ Both forms are valid and identical
+$var.total     // explicit prefix
+$total         // shorthand — same thing
+```
 
 ### Reserved Names
 

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -10,6 +10,36 @@ Essential patterns for XanoScript development. Use this as a quick reference for
 
 ## Quick Reference
 
+### Variable Access Rules
+
+**Inputs must use `$input.fieldname` — no shorthand exists.**
+
+Input fields declared in the `input {}` block are only accessible via the `$input` prefix. You cannot reference them as bare variables.
+
+```xs
+input {
+  text name
+  int age
+}
+
+// ❌ Wrong — $name is not defined; inputs live on $input
+var $greeting { value = "Hello, " ~ $name }
+
+// ✅ Correct
+var $greeting { value = "Hello, " ~ $input.name }
+var $is_adult { value = $input.age >= 18 }
+```
+
+**Stack variables have an optional `$var.` prefix — both forms are identical.**
+
+```xs
+var $total { value = 100 }
+
+// ✅ Both are the same thing
+$var.total       // explicit prefix form
+$total           // shorthand form (no prefix)
+```
+
 ### Reserved Variable Names
 
 These variable names are reserved and cannot be used:

--- a/src/xanoscript_docs/syntax.md
+++ b/src/xanoscript_docs/syntax.md
@@ -85,6 +85,29 @@ Working with...
 
 ## Quick Reference
 
+### Variable Access Prefixes
+
+| Prefix | Applies to | Shorthand? |
+|--------|-----------|------------|
+| `$input.field` | Input parameters | No — prefix always required |
+| `$var.field` | Stack variables | Yes — `$field` is identical |
+| `$auth.field` | Auth context | No |
+| `$env.NAME` | Environment variables | No |
+| `$db.table.field` | DB field refs (queries) | No |
+
+```xs
+// ❌ Wrong — input fields are NOT accessible as bare variables
+var $name { value = $name }      // undefined; inputs live on $input
+
+// ✅ Correct — always use $input for input fields
+var $name { value = $input.name }
+
+// ✅ Both are valid for stack variables
+var $total { value = 0 }
+$var.total      // explicit
+$total          // shorthand — same thing
+```
+
 ### Operators
 | Category | Operators |
 |----------|-----------|


### PR DESCRIPTION
## Summary

- **`$input.fieldname` is required** — input fields declared in the `input {}` block cannot be referenced as bare variables. This was previously not called out explicitly.
- **`$var.name` and `$name` are equivalent** — the `$var.` prefix on stack variables is optional; both forms reference the same thing.

## Changes

- `src/xanoscript_docs/syntax.md` — Added "Variable Access Prefixes" table + code example at the top of the Quick Reference section
- `src/xanoscript_docs/quickstart.md` — Added "Variable Access Rules" subsection (before Reserved Variable Names) with ❌/✅ examples
- `.claude/skills/xanoscript-docs-expert/references/xanoscript-language.md` — Updated the Access Patterns table and added a "Critical Distinction" subsection with examples

## Test plan

- [ ] Verify the new sections render correctly in the docs
- [ ] Confirm ❌/✅ code examples are accurate XanoScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)