### PR TITLE
Fix doc bugs, add tool annotations, and improve error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -69,6 +69,12 @@ export function handleCliDocs(args: CliDocsArgs): string {
  */
 export const cliDocsToolDefinition = {
   name: "cli_docs",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: `Get documentation for the Xano CLI. Use this to understand how to use the CLI for local development, code sync, and XanoScript execution.
 
 ## Topics

--- a/src/meta_api_docs/index.ts
+++ b/src/meta_api_docs/index.ts
@@ -87,6 +87,12 @@ export function handleMetaApiDocs(args: MetaApiDocsArgs): string {
  */
 export const metaApiDocsToolDefinition = {
   name: "meta_api_docs",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description: `Get documentation for Xano's Meta API. Use this to understand how to programmatically manage Xano workspaces, databases, APIs, functions, agents, and more.
 
 ## Topics

--- a/src/tools/mcp_version.ts
+++ b/src/tools/mcp_version.ts
@@ -104,6 +104,12 @@ export function mcpVersionTool(): ToolResult {
 
 export const mcpVersionToolDefinition = {
   name: "mcp_version",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Get the current version of the Xano Developer MCP server. " +
     "Returns the version string from package.json.",

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -502,6 +502,12 @@ export function validateXanoscriptTool(args: ValidateXanoscriptArgs): ToolResult
 
 export const validateXanoscriptToolDefinition = {
   name: "validate_xanoscript",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   description:
     "Validate XanoScript code for syntax errors. Supports multiple input methods:\n" +
     "- code: Raw XanoScript code as a string\n" +

--- a/src/tools/xanoscript_docs.ts
+++ b/src/tools/xanoscript_docs.ts
@@ -10,6 +10,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import {
   readXanoscriptDocsV2,
+  getTopicNames,
   getTopicDescriptions,
   type XanoscriptDocsArgs,
 } from "../xanoscript.js";
@@ -132,11 +133,18 @@ export const xanoscriptDocsToolDefinition = {
     "Call without parameters for overview (README). " +
     "Use 'topic' for specific documentation, or 'file_path' for context-aware docs based on the file you're editing. " +
     "Use mode='quick_reference' for compact syntax cheatsheet (recommended for context efficiency).",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   inputSchema: {
     type: "object",
     properties: {
       topic: {
         type: "string",
+        enum: getTopicNames(),
         description:
           "Documentation topic to retrieve. Call without any parameters to get the README overview. " +
           "Example: topic='syntax' for language syntax, topic='database' for database operations, topic='types' for type system.\n\n" +

--- a/src/xanoscript.test.ts
+++ b/src/xanoscript.test.ts
@@ -150,7 +150,7 @@ describe("xanoscript module", () => {
     });
 
     it("should match workspace.xs", () => {
-      const result = getDocsForFilePath("workspace.xs");
+      const result = getDocsForFilePath("workspace/workspace.xs");
       expect(result).toContain("syntax");
       expect(result).toContain("workspace");
     });
@@ -274,10 +274,10 @@ Even more content.
       expect(result).toContain("Documentation version:");
     });
 
-    it("should return error for unknown topic", () => {
-      const result = readXanoscriptDocsV2(DOCS_PATH, { topic: "nonexistent" });
-      expect(result).toContain('Error: Unknown topic "nonexistent"');
-      expect(result).toContain("Available topics:");
+    it("should throw for unknown topic", () => {
+      expect(() =>
+        readXanoscriptDocsV2(DOCS_PATH, { topic: "nonexistent" })
+      ).toThrow('Unknown topic "nonexistent"');
     });
 
     it("should return context-aware docs for file_path", () => {
@@ -314,11 +314,10 @@ Even more content.
       expect(quickResult).toContain("Mode: quick_reference");
     });
 
-    it("should return error for invalid docs path", () => {
-      const result = readXanoscriptDocsV2("/nonexistent/path", {
-        topic: "syntax",
-      });
-      expect(result).toContain("Error reading XanoScript documentation:");
+    it("should throw for invalid docs path", () => {
+      expect(() =>
+        readXanoscriptDocsV2("/nonexistent/path", { topic: "syntax" })
+      ).toThrow();
     });
   });
 

--- a/src/xanoscript_docs/cheatsheet.md
+++ b/src/xanoscript_docs/cheatsheet.md
@@ -6,7 +6,9 @@ applyTo: "**/*.xs"
 
 > **Purpose:** Quick reference for the 20 most common XanoScript patterns. For detailed documentation, use `xanoscript_docs({ topic: "<topic>" })`.
 
-## Variable Declaration
+## Quick Reference
+
+### Variable Declaration
 
 ```xs
 var $name { value = "initial" }
@@ -15,7 +17,7 @@ var $items { value = [] }
 var $data { value = { key: "value" } }
 ```
 
-## Conditionals
+### Conditionals
 
 ```xs
 conditional {
@@ -33,7 +35,7 @@ conditional {
 
 > **Note:** Use `elseif` (one word), not `else if`.
 
-## Switch
+### Switch
 
 ```xs
 switch ($input.status) {
@@ -51,7 +53,7 @@ switch ($input.status) {
 
 > **Note:** `break` goes **after** the closing `}` of each `case` block. The `default` case does not need `break`.
 
-## Loops
+### Loops
 
 ```xs
 // For each loop
@@ -81,7 +83,7 @@ var $names { value = $items|map:$$.name }
 var $active { value = $items|filter:$$.is_active }
 ```
 
-## Database CRUD
+### Database CRUD
 
 ```xs
 // Get single record by field
@@ -113,7 +115,7 @@ db.edit "user" {
 db.del "user" { field_name = "id", field_value = $input.user_id }
 ```
 
-## API Requests
+### API Requests
 
 ```xs
 api.request {
@@ -133,7 +135,7 @@ api.request {
 // $api_result.response.headers → Response headers
 ```
 
-## Error Handling
+### Error Handling
 
 ```xs
 // Precondition (stops execution if false)
@@ -159,7 +161,7 @@ throw {
 }
 ```
 
-## Error Types
+### Error Types
 
 | Type | HTTP Status | Use Case |
 |------|-------------|----------|
@@ -168,7 +170,7 @@ throw {
 | `notfound` | 404 | Resource doesn't exist |
 | `standard` | 500 | General errors |
 
-## Common Filters
+### Common Filters
 
 ```xs
 // String
@@ -210,7 +212,7 @@ $num|round:2                  // Round to 2 decimals
 $num|abs                      // Absolute value
 ```
 
-## Authentication Check
+### Authentication Check
 
 ```xs
 precondition ($auth.id != null) {
@@ -219,7 +221,7 @@ precondition ($auth.id != null) {
 }
 ```
 
-## Function Call
+### Function Call
 
 ```xs
 function.run "my_function" {
@@ -227,7 +229,7 @@ function.run "my_function" {
 } as $result
 ```
 
-## String Concatenation
+### String Concatenation
 
 ```xs
 // Basic
@@ -237,7 +239,7 @@ var $msg { value = "Hello, " ~ $input.name ~ "!" }
 var $msg { value = ($status|to_text) ~ ": " ~ ($data|json_encode) }
 ```
 
-## Common Type Names
+### Common Type Names
 
 | Use This | Not This |
 |----------|----------|
@@ -247,11 +249,11 @@ var $msg { value = ($status|to_text) ~ ": " ~ ($data|json_encode) }
 | `decimal` | float, number |
 | `type[]` | array, list |
 
-## Reserved Variables (Cannot Use)
+### Reserved Variables (Cannot Use)
 
 `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`
 
-## Input Block Syntax
+### Input Block Syntax
 
 `?` after the **type** = nullable, `?` after the **variable name** = optional (not required).
 

--- a/src/xanoscript_docs/debugging.md
+++ b/src/xanoscript_docs/debugging.md
@@ -113,7 +113,7 @@ debug.stop
 function "process_order" {
   input { int order_id }
   stack {
-    var $trace_id { value = |uuid }
+    security.create_uuid as $trace_id
 
     debug.log {
       label = "TRACE_START"

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -324,9 +324,11 @@ var $data {
 
 ```xs
 // Using foreach
-foreach ($items) { each as $item {
-  debug.log { value = $item.name }
-} }
+foreach ($items) {
+  each as $item {
+    debug.log { value = $item.name }
+  }
+}
 
 // Using map filter
 var $names { value = $items|map:$$.name }

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -298,7 +298,7 @@ precondition ($input.email|contains:"@") {
 | `db.query` | Filtered list | `db.query "users" { where = $db.users.active == true } as $users` |
 | `db.add` | Insert | `db.add "users" { data = { name: "John" } } as $new` |
 | `db.edit` | Update | `db.edit "users" { field_name = "id" field_value = 1 data = { name: "Jane" } }` |
-| `db.delete` | Delete | `db.delete "users" { field_name = "id" field_value = 1 }` |
+| `db.del` | Delete | `db.del "users" { field_name = "id" field_value = 1 }` |
 
 > **Full reference:** See `xanoscript_docs({ topic: "database" })` for joins, bulk operations, transactions, and more.
 
@@ -323,10 +323,10 @@ var $data {
 ### 4. Loop Through Array
 
 ```xs
-// Using each
-each ($items as $item) {
+// Using foreach
+foreach ($items) { each as $item {
   debug.log { value = $item.name }
-}
+} }
 
 // Using map filter
 var $names { value = $items|map:$$.name }

--- a/src/xanoscript_docs/security.md
+++ b/src/xanoscript_docs/security.md
@@ -96,7 +96,7 @@ function "refresh_auth" {
     } as $new_token
 
     // Rotate refresh token
-    var $new_refresh { value = |uuid }
+    security.create_uuid as $new_refresh
 
     db.edit "refresh_token" {
       field_name = "id"
@@ -120,7 +120,7 @@ function "refresh_auth" {
 function "create_session" {
   input { int user_id }
   stack {
-    var $session_id { value = |uuid }
+    security.create_uuid as $session_id
 
     db.add "session" {
       data = {

--- a/src/xanoscript_docs/unit-testing.md
+++ b/src/xanoscript_docs/unit-testing.md
@@ -107,34 +107,34 @@ function "add" {
 ### Value Assertions
 
 ```xs
-# Equality
+// Equality
 expect.to_equal ($response.status) { value = "active" }
 expect.to_not_equal ($response.status) { value = "deleted" }
 
-# Boolean
+// Boolean
 expect.to_be_true ($response.is_active)
 expect.to_be_false ($response.is_deleted)
 
-# Null
+// Null
 expect.to_be_null ($response.deleted_at)
 expect.to_not_be_null ($response.created_at)
 
-# Defined
+// Defined
 expect.to_be_defined ($response.id)
 expect.to_not_be_defined ($response.optional_field)
 
-# Empty
+// Empty
 expect.to_be_empty ($response.errors)
 ```
 
 ### Comparison Assertions
 
 ```xs
-# Numeric comparisons
+// Numeric comparisons
 expect.to_be_greater_than ($response.total) { value = 100 }
 expect.to_be_less_than ($response.stock) { value = 10 }
 
-# Range
+// Range
 expect.to_be_within ($response.temperature) {
   min = 20
   max = 30
@@ -144,14 +144,14 @@ expect.to_be_within ($response.temperature) {
 ### String Assertions
 
 ```xs
-# Starts/ends with
+// Starts/ends with
 expect.to_start_with ($response.name) { value = "John" }
 expect.to_end_with ($response.file) { value = ".pdf" }
 
-# Contains
+// Contains
 expect.to_contain ($response.tags) { value = "featured" }
 
-# Regex match
+// Regex match
 expect.to_match ($response.phone) { value = "^\\+1\\d{10}$" }
 ```
 
@@ -165,13 +165,13 @@ expect.to_be_in_the_future ($response.expires_at)
 ### Error Assertions
 
 ```xs
-# Expects any error
+// Expects any error
 test "throws on invalid input" {
   input = { amount: -1 }
   expect.to_throw
 }
 
-# Expects specific error
+// Expects specific error
 test "throws validation error" {
   input = { amount: -1 }
   expect.to_throw { value = "InvalidInputError" }


### PR DESCRIPTION
## Summary

- **Fix documentation bugs** that cause incorrect AI-generated code: `db.delete` → `db.del`, `#` → `//` comments, non-standard `each` loop syntax → `foreach`, `|uuid` → `security.create_uuid`
- **Add MCP tool annotations** (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all 5 tool definitions
- **Add `enum` constraint** to `xanoscript_docs` topic parameter for schema-level validation
- **Fix cheatsheet Quick Reference mode** so `extractQuickReference` captures the full cheatsheet instead of just the title
- **Fix error propagation** — `readXanoscriptDocsV2` now throws errors instead of returning error strings, enabling proper `isError: true` MCP responses

## Test plan

- [x] All 82 tests passing
- [x] Build succeeds
- [ ] Verify `xanoscript_docs({ topic: "cheatsheet", mode: "quick_reference" })` returns full cheatsheet content
- [ ] Verify unknown topic returns `isError: true` in MCP response

🤖 Generated with [Claude Code](https://claude.com/claude-code)