### PR TITLE
Reduce context window usage for file_path doc lookups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/tools/xanoscript_docs.ts
+++ b/src/tools/xanoscript_docs.ts
@@ -132,7 +132,8 @@ export const xanoscriptDocsToolDefinition = {
     "Get XanoScript programming language documentation for AI code generation. " +
     "Call without parameters for overview (README). " +
     "Use 'topic' for specific documentation, or 'file_path' for context-aware docs based on the file you're editing. " +
-    "Use mode='quick_reference' for compact syntax cheatsheet (recommended for context efficiency).",
+    "Use mode='quick_reference' for compact syntax cheatsheet (recommended for context efficiency). " +
+    "file_path mode defaults to 'quick_reference' to reduce context size; use mode='full' to get complete docs.",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,
@@ -165,7 +166,15 @@ export const xanoscriptDocsToolDefinition = {
           "'full' = complete documentation with explanations and examples. " +
           "'quick_reference' = compact cheatsheet with just syntax patterns and signatures. " +
           "Use 'quick_reference' to save context window space when you just need a reminder. " +
-          "Default: 'full'.",
+          "Default: 'full' for topic mode, 'quick_reference' for file_path mode.",
+      },
+      exclude_topics: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "List of topic names to exclude from file_path results. " +
+          "Use this to skip topics you've already loaded (e.g., exclude_topics: ['syntax', 'quickstart']). " +
+          "Only applies when using file_path parameter.",
       },
     },
     required: [],


### PR DESCRIPTION
## Summary
- **Narrow `applyTo` patterns**: Removed 5 niche topics (`realtime`, `schema`, `streaming`, `addons`, `integrations`) from broad `functions/**/*.xs` and `apis/**/*.xs` globs, reducing file_path matches from ~15 topics to ~8-10
- **Add `exclude_topics` parameter**: New `string[]` input lets AIs skip already-loaded topics (e.g., `exclude_topics: ["syntax", "quickstart"]`)
- **Default to `quick_reference` for `file_path` mode**: ~87% size reduction when loading context-aware docs; `mode: "full"` still available explicitly

## Test plan
- [x] All 86 existing tests pass with updated assertions
- [x] New tests for `exclude_topics` filtering
- [x] New tests for `quick_reference` default in file_path mode
- [x] TypeScript compiles clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)