### PR TITLE
Fix doc content quality: backticks, commas, incorrect operations, stale refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -183,7 +183,7 @@ Use `xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
 | Topic        | Description                                          | Key Sections |
 | ------------ | ---------------------------------------------------- | ------------ |
 | `quickstart` | Common patterns, quick examples, mistakes to avoid   | Patterns, Common Mistakes |
-| `syntax`     | Expressions, operators, filters, system variables    | Filters (L179-275), Error Handling (L411-477) |
+| `syntax`     | Expressions, operators, filters, system variables    | Filters, Error Handling |
 | `types`      | Data types, validation, input blocks                 | Validation Filters, Input Blocks |
 | `functions`  | Reusable function stacks, async, loops               | Loops, Async Patterns |
 | `schema`     | Runtime schema parsing and validation                | parse.object, parse.array |
@@ -193,7 +193,7 @@ Use `xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
 | Topic       | Description                                                | Key Sections |
 | ----------- | ---------------------------------------------------------- | ------------ |
 | `tables`    | Database schema definitions with indexes and relationships | Indexes, Foreign Keys |
-| `database`  | All db.\* operations: query, get, add, edit, patch, delete | Decision Tree (L11), Bulk Ops (L450-529) |
+| `database`  | All db.\* operations: query, get, add, edit, patch, delete | Decision Tree, Bulk Ops |
 | `addons`    | Reusable subqueries for fetching related data              | Usage Patterns |
 | `streaming` | Streaming data from files, requests, and responses         | File Streams, API Streams |
 
@@ -201,7 +201,7 @@ Use `xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
 
 | Topic      | Description                                                     | Key Sections |
 | ---------- | --------------------------------------------------------------- | ------------ |
-| `apis`     | HTTP endpoint definitions with authentication and CRUD patterns | Decision Tree (L9), CRUD Examples (L220-350) |
+| `apis`     | HTTP endpoint definitions with authentication and CRUD patterns | Decision Tree, CRUD Examples |
 | `tasks`    | Scheduled and cron jobs                                         | Cron Syntax, Input Handling |
 | `triggers` | Event-driven handlers (table, realtime, workspace, agent, MCP)  | Predefined Inputs, Event Types |
 | `realtime` | Real-time channels and events for push updates                  | Channels, Events |

--- a/src/xanoscript_docs/cheatsheet.md
+++ b/src/xanoscript_docs/cheatsheet.md
@@ -112,7 +112,10 @@ db.edit "user" {
 }
 
 // Delete record
-db.del "user" { field_name = "id", field_value = $input.user_id }
+db.del "user" {
+  field_name = "id"
+  field_value = $input.user_id
+}
 ```
 
 ### API Requests

--- a/src/xanoscript_docs/database.md
+++ b/src/xanoscript_docs/database.md
@@ -613,7 +613,7 @@ try_catch {
     conditional {
       if ($error.name == "DeadlockError") {
         // Retry logic
-        util.sleep { value = 100 }
+        util.sleep { value = 1 }                // value = seconds
         function.run "retry_transaction" { input = $input }
       }
       else {

--- a/src/xanoscript_docs/docs_index.json
+++ b/src/xanoscript_docs/docs_index.json
@@ -220,8 +220,6 @@
     "function.run": { "file": "functions.md" },
     "redis.get": { "file": "integrations/redis.md" },
     "redis.set": { "file": "integrations/redis.md" },
-    "storage.s3_put": { "file": "integrations/cloud-storage.md" },
-    "storage.s3_get": { "file": "integrations/cloud-storage.md" },
     "array.push": { "file": "syntax.md" },
     "array.pop": { "file": "syntax.md" },
     "array.shift": { "file": "syntax.md" },

--- a/src/xanoscript_docs/middleware.md
+++ b/src/xanoscript_docs/middleware.md
@@ -239,28 +239,15 @@ middleware "rate_limit" {
   }
 
   stack {
-    var $key { value = "ratelimit:" ~ $input.user_id }
-
-    redis.incr {
-      key = $key
-    } as $count
-
-    conditional {
-      if ($count == 1) {
-        redis.expire {
-          key = $key
-          seconds = $input.window_seconds
-        }
-      }
-    }
-
-    precondition ($count <= $input.max_requests) {
-      error_type = "standard"
+    redis.ratelimit {
+      key = "ratelimit:" ~ $input.user_id
+      max = $input.max_requests
+      ttl = $input.window_seconds
       error = "Rate limit exceeded"
     }
   }
 
-  response = { remaining: $input.max_requests - $count }
+  response = null
 }
 ```
 

--- a/src/xanoscript_docs/quickstart.md
+++ b/src/xanoscript_docs/quickstart.md
@@ -107,10 +107,10 @@ var $data { value = { key: "value" } }
 ### Conditional Logic
 ```xs
 conditional {
-  if (`$status == "active"`) {
+  if ($status == "active") {
     var $result { value = "Active user" }
   }
-  elseif (`$status == "pending"`) {
+  elseif ($status == "pending") {
     var $result { value = "Pending approval" }
   }
   else {
@@ -464,7 +464,7 @@ conditional {
   }
   else {
     throw {
-      name = "APIError",
+      name = "APIError"
       value = "OpenAI API error: " ~ ($api_result.response.status|to_text)
     }
   }
@@ -574,19 +574,28 @@ var $data { value = { customer = $id } }
 var $data { value = { customer: $id } }
 ```
 
-### 9. Throw block with commas
+### 9. Commas in block properties (`=`) vs object literals (`:`)
+
+Block properties use `=` and go on **separate lines with no commas**. Object literals use `:` and **require commas** between entries.
+
 ```xs
-// ❌ Wrong - throw blocks don't use commas
+// ❌ Wrong - block properties don't use commas
 throw {
   name = "Error",
   value = "message"
 }
 
-// ✅ Correct - no commas between properties
+// ✅ Correct - no commas between block properties (=)
 throw {
   name = "Error"
   value = "message"
 }
+
+// ✅ Correct - object literals (:) DO use commas
+db.query "dad_jokes" {
+  sort = {dad_jokes.id: "rand", dad_jokes.joke: "asc"}
+  return = {type: "single"}
+} as $joke
 ```
 
 ### 10. Using $env in run.job input blocks

--- a/src/xanoscript_docs/syntax.md
+++ b/src/xanoscript_docs/syntax.md
@@ -179,10 +179,10 @@ Use `conditional` blocks for if/elseif/else logic:
 
 ```xs
 conditional {
-  if (`$status == "success"`) {
+  if ($status == "success") {
     var $message { value = "All good!" }
   }
-  elseif (`$status == "pending"`) {
+  elseif ($status == "pending") {
     var $message { value = "Please wait..." }
   }
   else {
@@ -214,14 +214,16 @@ conditional {
 
 ## Expressions
 
-Expressions are wrapped in backticks for evaluation:
+Backticks enter **expression mode** — use them only when you need inline evaluation of a complex expression, not for regular conditionals or variable assignments.
 
 ```xs
+// ✅ Regular conditionals — no backticks needed
 conditional {
-  if (`$input.age >= 18`) { ... }
+  if ($input.age >= 18) { ... }
 }
 
-var $total { value = `$input.qty * $input.price` }
+// ✅ Variable assignment — no backticks needed
+var $total { value = $input.qty * $input.price }
 ```
 
 ### Comparison

--- a/src/xanoscript_docs/triggers.md
+++ b/src/xanoscript_docs/triggers.md
@@ -576,7 +576,7 @@ mcp_server_trigger "database_tool_handler" {
       value = {
         server: $input.toolset.name,
         instructions: $input.toolset.instructions,
-        tool_count: count($input.tools)
+        tool_count: $input.tools|count
       }
     }
   }


### PR DESCRIPTION
## Summary
- **Backtick cleanup (3.1):** Removed unnecessary backticks from conditional examples in syntax.md and quickstart.md; clarified that backticks are only for expression mode
- **Comma rules (3.2):** Fixed db.del and throw block comma usage; expanded Common Mistake #9 to explain `=` (no commas) vs `:` (commas required) with examples
- **Incorrect operations (3.3):** Replaced 7 nonexistent operations (`redis.expire`, `html_sanitize`, `alphaNumOk`, `count()`, `security.verify_totp`) with correct alternatives across 6 doc files
- **Stale references (3.4):** Removed all `(Lxx)` line number references from README.md and security.md
- **Index drift (3.5):** Removed duplicate `storage.s3_put`/`storage.s3_get` entries from docs_index.json

## Files Changed (10)
| File | Changes |
|------|---------|
| `syntax.md` | Remove backticks from conditionals, clarify expression mode |
| `quickstart.md` | Remove backticks, fix throw comma, expand Mistake #9 |
| `cheatsheet.md` | Fix db.del to multi-line without commas |
| `security.md` | Fix redis.expire, html_sanitize, alphaNumOk, remove verify_totp, remove stale line refs |
| `middleware.md` | Replace manual rate limiting with redis.ratelimit |
| `triggers.md` | Replace count() with \|count filter |
| `database.md` | Fix util.sleep value (100→1 second) |
| `README.md` | Remove stale line number references |
| `docs_index.json` | Remove duplicate s3 entries |
| `package.json` | Version bump |

## Test plan
- [x] All 86 tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] Verify XanoScript docs tool returns corrected examples
- [ ] Spot-check that AI code generation uses correct patterns (no backticks in conditionals, no commas in block properties)

🤖 Generated with [Claude Code](https://claude.com/claude-code)