### PR TITLE
Architecture improvements and advanced MCP features (iterations 5 & 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -109,4 +109,14 @@ ${getTopicDescriptions()}
     },
     required: ["topic"],
   },
+  outputSchema: {
+    type: "object",
+    properties: {
+      documentation: {
+        type: "string",
+        description: "The CLI documentation content for the requested topic.",
+      },
+    },
+    required: ["documentation"],
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   toolDefinitions,
   handleTool,
   toMcpResponse,
+  getXanoscriptDocsPath,
 } from "./tools/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -40,26 +41,8 @@ if (process.argv.includes("--version") || process.argv.includes("-v")) {
 }
 
 // =============================================================================
-// Path Resolution
+// Path Resolution (uses shared path from tools/xanoscript_docs.ts)
 // =============================================================================
-
-function getXanoscriptDocsPath(): string {
-  const possiblePaths = [
-    join(__dirname, "xanoscript_docs"),           // dist/xanoscript_docs (production)
-    join(__dirname, "..", "src", "xanoscript_docs"), // src/xanoscript_docs (dev before build)
-  ];
-
-  for (const p of possiblePaths) {
-    try {
-      readFileSync(join(p, "version.json"));
-      return p;
-    } catch {
-      continue;
-    }
-  }
-
-  return join(__dirname, "xanoscript_docs");
-}
 
 const XANOSCRIPT_DOCS_PATH = getXanoscriptDocsPath();
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -61,6 +61,7 @@ export {
   setXanoscriptDocsPath,
   type XanoscriptDocsArgs,
   type XanoscriptDocsResult,
+  type TopicDoc,
 } from "./tools/xanoscript_docs.js";
 
 // MCP Version
@@ -104,9 +105,11 @@ export { type ToolResult, toMcpResponse } from "./tools/types.js";
 export {
   XANOSCRIPT_DOCS_V2,
   readXanoscriptDocsV2,
+  readXanoscriptDocsStructured,
   getDocsForFilePath,
   extractQuickReference,
   getXanoscriptDocsVersion,
+  clearDocsCache,
   getTopicNames as getXanoscriptTopicNames,
   getTopicDescriptions as getXanoscriptTopicDescriptions,
   type DocConfig,

--- a/src/meta_api_docs/index.ts
+++ b/src/meta_api_docs/index.ts
@@ -135,4 +135,14 @@ ${getTopicDescriptions()}
     },
     required: ["topic"],
   },
+  outputSchema: {
+    type: "object",
+    properties: {
+      documentation: {
+        type: "string",
+        description: "The Meta API documentation content for the requested topic.",
+      },
+    },
+    required: ["documentation"],
+  },
 };

--- a/src/tools/cli_docs.ts
+++ b/src/tools/cli_docs.ts
@@ -83,6 +83,7 @@ export function cliDocsTool(args: CliDocsArgs): ToolResult {
     return {
       success: true,
       data: result.documentation,
+      structuredContent: { documentation: result.documentation },
     };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
+import {
+  handleTool,
+  toMcpResponse,
+  toolDefinitions,
+} from "./index.js";
+import { setXanoscriptDocsPath } from "./xanoscript_docs.js";
+import { XANOSCRIPT_DOCS_V2 } from "../xanoscript.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DOCS_PATH = join(__dirname, "..", "xanoscript_docs");
+
+beforeAll(() => {
+  setXanoscriptDocsPath(DOCS_PATH);
+});
+
+describe("handleTool", () => {
+  it("should handle xanoscript_docs tool", () => {
+    const result = handleTool("xanoscript_docs", {});
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+  });
+
+  it("should handle xanoscript_docs with topic arg", () => {
+    const result = handleTool("xanoscript_docs", { topic: "syntax" });
+    expect(result.success).toBe(true);
+    expect(typeof result.data).toBe("string");
+    expect(result.data).toContain("Documentation version:");
+  });
+
+  it("should handle xanoscript_docs with file_path and return multi-content", () => {
+    const result = handleTool("xanoscript_docs", { file_path: "apis/users/create.xs" });
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.data)).toBe(true);
+    const data = result.data as string[];
+    expect(data.length).toBeGreaterThan(1);
+    expect(data[0]).toContain("Matched topics:");
+  });
+
+  it("should handle validate_xanoscript tool and return a ToolResult", () => {
+    const result = handleTool("validate_xanoscript", { code: "var $x:int = 1" });
+    expect(result).toHaveProperty("success");
+    expect(typeof result.success).toBe("boolean");
+    // Either data or error should be present
+    expect(result.data ?? result.error).toBeDefined();
+  });
+
+  it("should handle validate_xanoscript with missing input", () => {
+    const result = handleTool("validate_xanoscript", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("should handle mcp_version tool", () => {
+    const result = handleTool("mcp_version", {});
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+  });
+
+  it("should handle meta_api_docs tool with topic", () => {
+    const result = handleTool("meta_api_docs", { topic: "start" });
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+  });
+
+  it("should handle meta_api_docs tool without topic", () => {
+    const result = handleTool("meta_api_docs", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("topic");
+  });
+
+  it("should handle cli_docs tool with topic", () => {
+    const result = handleTool("cli_docs", { topic: "start" });
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+  });
+
+  it("should handle cli_docs tool without topic", () => {
+    const result = handleTool("cli_docs", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("topic");
+  });
+
+  it("should return error for unknown tool", () => {
+    const result = handleTool("nonexistent_tool", {});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unknown tool: nonexistent_tool");
+  });
+
+  it("should return validation error for wrong argument types", () => {
+    const result = handleTool("xanoscript_docs", { mode: 123 });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid arguments");
+  });
+
+  it("should return validation error for invalid enum value", () => {
+    const result = handleTool("xanoscript_docs", { mode: "invalid_mode" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid arguments");
+  });
+
+  it("should return validation error when meta_api_docs topic is wrong type", () => {
+    const result = handleTool("meta_api_docs", { topic: 123 });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid arguments");
+  });
+});
+
+describe("toMcpResponse", () => {
+  it("should convert success result to MCP response", () => {
+    const response = toMcpResponse({ success: true, data: "test data" });
+    expect(response.content).toHaveLength(1);
+    expect(response.content[0].type).toBe("text");
+    expect(response.content[0].text).toBe("test data");
+    expect(response.isError).toBeUndefined();
+  });
+
+  it("should convert error result to MCP response with isError", () => {
+    const response = toMcpResponse({ success: false, error: "test error" });
+    expect(response.content).toHaveLength(1);
+    expect(response.content[0].text).toBe("test error");
+    expect(response.isError).toBe(true);
+  });
+
+  it("should convert string array data to multiple content blocks", () => {
+    const response = toMcpResponse({
+      success: true,
+      data: ["block one", "block two", "block three"],
+    });
+    expect(response.content).toHaveLength(3);
+    expect(response.content[0]).toEqual({ type: "text", text: "block one" });
+    expect(response.content[1]).toEqual({ type: "text", text: "block two" });
+    expect(response.content[2]).toEqual({ type: "text", text: "block three" });
+    expect(response.isError).toBeUndefined();
+  });
+
+  it("should handle single-element array data", () => {
+    const response = toMcpResponse({ success: true, data: ["only block"] });
+    expect(response.content).toHaveLength(1);
+    expect(response.content[0].text).toBe("only block");
+  });
+
+  it("should include structuredContent when provided", () => {
+    const response = toMcpResponse({
+      success: true,
+      data: "test",
+      structuredContent: { version: "1.0.0" },
+    });
+    expect(response.structuredContent).toEqual({ version: "1.0.0" });
+    expect(response.isError).toBeUndefined();
+  });
+
+  it("should omit structuredContent when not provided", () => {
+    const response = toMcpResponse({ success: true, data: "test" });
+    expect(response.structuredContent).toBeUndefined();
+  });
+
+  it("should not include structuredContent on error", () => {
+    const response = toMcpResponse({ success: false, error: "fail" });
+    expect(response.structuredContent).toBeUndefined();
+    expect(response.isError).toBe(true);
+  });
+});
+
+describe("toolDefinitions", () => {
+  it("should contain all 5 tools", () => {
+    expect(toolDefinitions).toHaveLength(5);
+  });
+
+  it("should have unique tool names", () => {
+    const names = toolDefinitions.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("should include expected tool names", () => {
+    const names = toolDefinitions.map((t) => t.name);
+    expect(names).toContain("validate_xanoscript");
+    expect(names).toContain("xanoscript_docs");
+    expect(names).toContain("mcp_version");
+    expect(names).toContain("meta_api_docs");
+    expect(names).toContain("cli_docs");
+  });
+
+  it("should have annotations on all tools", () => {
+    for (const tool of toolDefinitions) {
+      expect(tool).toHaveProperty("annotations");
+      expect(tool.annotations).toHaveProperty("readOnlyHint");
+      expect(tool.annotations).toHaveProperty("destructiveHint", false);
+    }
+  });
+
+  it("should have outputSchema on all tools", () => {
+    for (const tool of toolDefinitions) {
+      expect(tool).toHaveProperty("outputSchema");
+      expect((tool as Record<string, unknown>).outputSchema).toHaveProperty("type", "object");
+      expect((tool as Record<string, unknown>).outputSchema).toHaveProperty("properties");
+    }
+  });
+});
+
+describe("integration: all topic files exist on disk", () => {
+  for (const [topic, config] of Object.entries(XANOSCRIPT_DOCS_V2)) {
+    it(`topic "${topic}" -> file "${config.file}" should exist`, () => {
+      const filePath = join(DOCS_PATH, config.file);
+      expect(existsSync(filePath)).toBe(true);
+    });
+  }
+});

--- a/src/tools/mcp_version.ts
+++ b/src/tools/mcp_version.ts
@@ -92,9 +92,11 @@ export function mcpVersion(): McpVersionResult {
  * Get the MCP version and return a ToolResult.
  */
 export function mcpVersionTool(): ToolResult {
+  const version = getServerVersion();
   return {
     success: true,
-    data: getServerVersion(),
+    data: version,
+    structuredContent: { version },
   };
 }
 
@@ -117,5 +119,15 @@ export const mcpVersionToolDefinition = {
     type: "object",
     properties: {},
     required: [],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      version: {
+        type: "string",
+        description: "The semantic version string of the MCP server.",
+      },
+    },
+    required: ["version"],
   },
 };

--- a/src/tools/meta_api_docs.ts
+++ b/src/tools/meta_api_docs.ts
@@ -84,6 +84,7 @@ export function metaApiDocsTool(args: MetaApiDocsArgs): ToolResult {
     return {
       success: true,
       data: result.documentation,
+      structuredContent: { documentation: result.documentation },
     };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -2,26 +2,37 @@
  * Common types for tool results
  */
 
-export interface ToolResult {
-  success: boolean;
-  data?: string;
-  error?: string;
-}
+export type ToolResult =
+  | {
+      success: true;
+      data: string | string[];
+      structuredContent?: Record<string, unknown>;
+      error?: undefined;
+    }
+  | { success: false; error: string; data?: undefined; structuredContent?: undefined };
 
 /**
- * Convert a ToolResult to MCP tool response format
+ * Convert a ToolResult to MCP tool response format.
+ * When data is a string[], each element becomes a separate content block.
+ * When structuredContent is provided, it's included for clients that support outputSchema.
  */
 export function toMcpResponse(result: ToolResult): {
   content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 } {
   if (result.success) {
-    return {
-      content: [{ type: "text", text: result.data! }],
-    };
+    const content = Array.isArray(result.data)
+      ? result.data.map((text) => ({ type: "text" as const, text }))
+      : [{ type: "text" as const, text: result.data }];
+
+    if (result.structuredContent) {
+      return { content, structuredContent: result.structuredContent };
+    }
+    return { content };
   }
   return {
-    content: [{ type: "text", text: result.error! }],
+    content: [{ type: "text", text: result.error }],
     isError: true,
   };
 }

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -489,11 +489,14 @@ export function validateXanoscript(
  */
 export function validateXanoscriptTool(args: ValidateXanoscriptArgs): ToolResult {
   const result = validateXanoscript(args);
-  return {
-    success: result.valid,
-    data: result.valid ? result.message : undefined,
-    error: result.valid ? undefined : result.message,
-  };
+  if (result.valid) {
+    return {
+      success: true,
+      data: result.message,
+      structuredContent: { valid: true, message: result.message },
+    };
+  }
+  return { success: false, error: result.message };
 }
 
 // =============================================================================
@@ -552,6 +555,21 @@ export const validateXanoscriptToolDefinition = {
       },
     },
     required: [],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      valid: {
+        type: "boolean",
+        description: "Whether the code passed validation without errors.",
+      },
+      message: {
+        type: "string",
+        description:
+          "Human-readable validation summary with error details if any.",
+      },
+    },
+    required: ["valid", "message"],
   },
 };
 

--- a/src/tools/xanoscript_docs.test.ts
+++ b/src/tools/xanoscript_docs.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import {
+  getXanoscriptDocsPath,
+  setXanoscriptDocsPath,
+  xanoscriptDocs,
+  xanoscriptDocsTool,
+} from "./xanoscript_docs.js";
+import { toMcpResponse } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DOCS_PATH = join(__dirname, "..", "xanoscript_docs");
+
+afterEach(() => {
+  // Reset to default so tests don't interfere with each other
+  setXanoscriptDocsPath(DOCS_PATH);
+});
+
+describe("getXanoscriptDocsPath", () => {
+  it("should return a string path", () => {
+    const path = getXanoscriptDocsPath();
+    expect(typeof path).toBe("string");
+    expect(path.length).toBeGreaterThan(0);
+  });
+
+  it("should return a path ending with xanoscript_docs", () => {
+    const path = getXanoscriptDocsPath();
+    expect(path).toMatch(/xanoscript_docs$/);
+  });
+
+  it("should return a consistent path on repeated calls", () => {
+    const path1 = getXanoscriptDocsPath();
+    const path2 = getXanoscriptDocsPath();
+    expect(path1).toBe(path2);
+  });
+});
+
+describe("setXanoscriptDocsPath", () => {
+  it("should override the docs path", () => {
+    const customPath = "/custom/docs/path";
+    setXanoscriptDocsPath(customPath);
+    expect(getXanoscriptDocsPath()).toBe(customPath);
+  });
+
+  it("should be used by xanoscriptDocs when set", () => {
+    setXanoscriptDocsPath(DOCS_PATH);
+    const result = xanoscriptDocs();
+    expect(result.documentation).toContain("Documentation version:");
+  });
+});
+
+describe("xanoscriptDocs", () => {
+  it("should return README when called with no args", () => {
+    const result = xanoscriptDocs();
+    expect(result).toHaveProperty("documentation");
+    expect(typeof result.documentation).toBe("string");
+    expect(result.documentation).toContain("Documentation version:");
+  });
+
+  it("should return specific topic documentation", () => {
+    const result = xanoscriptDocs({ topic: "syntax" });
+    expect(result.documentation).toContain("Documentation version:");
+  });
+
+  it("should return context-aware docs for file_path", () => {
+    const result = xanoscriptDocs({ file_path: "apis/users/create.xs" });
+    expect(result.documentation).toContain("XanoScript Documentation for:");
+    expect(result.documentation).toContain("Matched topics:");
+  });
+
+  it("should support quick_reference mode", () => {
+    const full = xanoscriptDocs({ topic: "syntax", mode: "full" });
+    const quick = xanoscriptDocs({ topic: "syntax", mode: "quick_reference" });
+    expect(quick.documentation.length).toBeLessThanOrEqual(full.documentation.length);
+  });
+
+  it("should throw for unknown topic", () => {
+    expect(() => xanoscriptDocs({ topic: "nonexistent" })).toThrow(
+      'Unknown topic "nonexistent"'
+    );
+  });
+
+  it("should throw for invalid docs path", () => {
+    setXanoscriptDocsPath("/nonexistent/path");
+    expect(() => xanoscriptDocs({ topic: "syntax" })).toThrow();
+  });
+});
+
+describe("xanoscriptDocsTool", () => {
+  it("should return success with data for valid call", () => {
+    const result = xanoscriptDocsTool();
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    expect(typeof result.data).toBe("string");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("should return success with topic docs", () => {
+    const result = xanoscriptDocsTool({ topic: "syntax" });
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("Documentation version:");
+  });
+
+  it("should return error for unknown topic", () => {
+    const result = xanoscriptDocsTool({ topic: "nonexistent" });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("Unknown topic");
+  });
+
+  it("should return error for invalid docs path", () => {
+    setXanoscriptDocsPath("/nonexistent/path");
+    const result = xanoscriptDocsTool({ topic: "syntax" });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("Error retrieving XanoScript documentation");
+  });
+
+  it("should return multi-content array for file_path mode", () => {
+    const result = xanoscriptDocsTool({ file_path: "apis/users/create.xs" });
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.data)).toBe(true);
+    const data = result.data as string[];
+    // First element is the header
+    expect(data[0]).toContain("XanoScript Documentation for: apis/users/create.xs");
+    expect(data[0]).toContain("Matched topics:");
+    expect(data[0]).toContain("Version:");
+    // Remaining elements are per-topic content
+    expect(data.length).toBeGreaterThan(1);
+  });
+
+  it("should return single string for topic mode", () => {
+    const result = xanoscriptDocsTool({ topic: "syntax" });
+    expect(result.success).toBe(true);
+    expect(typeof result.data).toBe("string");
+    expect(Array.isArray(result.data)).toBe(false);
+  });
+
+  it("should return single string for no-args mode", () => {
+    const result = xanoscriptDocsTool();
+    expect(result.success).toBe(true);
+    expect(typeof result.data).toBe("string");
+    expect(Array.isArray(result.data)).toBe(false);
+  });
+
+  it("should produce multiple MCP content blocks for file_path via toMcpResponse", () => {
+    const result = xanoscriptDocsTool({ file_path: "apis/users/create.xs" });
+    const mcpResponse = toMcpResponse(result);
+    expect(mcpResponse.isError).toBeUndefined();
+    // Should have multiple content blocks (header + N topics)
+    expect(mcpResponse.content.length).toBeGreaterThan(1);
+    // All blocks should be text type
+    for (const block of mcpResponse.content) {
+      expect(block.type).toBe("text");
+      expect(typeof block.text).toBe("string");
+    }
+  });
+
+  it("should produce single MCP content block for topic mode via toMcpResponse", () => {
+    const result = xanoscriptDocsTool({ topic: "syntax" });
+    const mcpResponse = toMcpResponse(result);
+    expect(mcpResponse.content).toHaveLength(1);
+    expect(mcpResponse.content[0].type).toBe("text");
+  });
+
+  it("should include structuredContent for file_path mode", () => {
+    const result = xanoscriptDocsTool({ file_path: "apis/users/create.xs" });
+    expect(result.success).toBe(true);
+    expect(result.structuredContent).toBeDefined();
+    expect(result.structuredContent).toHaveProperty("file_path", "apis/users/create.xs");
+    expect(result.structuredContent).toHaveProperty("mode", "quick_reference");
+    expect(result.structuredContent).toHaveProperty("version");
+    expect(result.structuredContent).toHaveProperty("topics");
+    expect(Array.isArray(result.structuredContent!.topics)).toBe(true);
+  });
+
+  it("should include structuredContent for topic mode", () => {
+    const result = xanoscriptDocsTool({ topic: "syntax" });
+    expect(result.success).toBe(true);
+    expect(result.structuredContent).toBeDefined();
+    expect(result.structuredContent).toHaveProperty("documentation");
+  });
+
+  it("should include structuredContent in MCP response", () => {
+    const result = xanoscriptDocsTool({ file_path: "apis/users/create.xs" });
+    const mcpResponse = toMcpResponse(result);
+    expect(mcpResponse.structuredContent).toBeDefined();
+    expect(mcpResponse.structuredContent).toHaveProperty("file_path");
+    expect(mcpResponse.structuredContent).toHaveProperty("topics");
+  });
+});
+
+describe("xanoscriptDocs structured output", () => {
+  it("should include topics array for file_path mode", () => {
+    const result = xanoscriptDocs({ file_path: "apis/users/create.xs" });
+    expect(result.topics).toBeDefined();
+    expect(Array.isArray(result.topics)).toBe(true);
+    expect(result.topics!.length).toBeGreaterThan(0);
+  });
+
+  it("should have topic and content fields in each TopicDoc", () => {
+    const result = xanoscriptDocs({ file_path: "apis/users/create.xs" });
+    for (const doc of result.topics!) {
+      expect(doc).toHaveProperty("topic");
+      expect(doc).toHaveProperty("content");
+      expect(typeof doc.topic).toBe("string");
+      expect(typeof doc.content).toBe("string");
+      expect(doc.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should not include topics array for topic mode", () => {
+    const result = xanoscriptDocs({ topic: "syntax" });
+    expect(result.topics).toBeUndefined();
+  });
+
+  it("should not include topics array for no-args mode", () => {
+    const result = xanoscriptDocs();
+    expect(result.topics).toBeUndefined();
+  });
+
+  it("should respect exclude_topics in structured output", () => {
+    const result = xanoscriptDocs({
+      file_path: "apis/users/create.xs",
+      exclude_topics: ["syntax", "essentials"],
+    });
+    expect(result.topics).toBeDefined();
+    const topicNames = result.topics!.map((d) => d.topic);
+    expect(topicNames).not.toContain("syntax");
+    expect(topicNames).not.toContain("essentials");
+  });
+});

--- a/src/xanoscript.ts
+++ b/src/xanoscript.ts
@@ -8,6 +8,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { minimatch } from "minimatch";
+import docsIndex from "./xanoscript_docs/docs_index.json" with { type: "json" };
 
 // =============================================================================
 // Types
@@ -22,196 +23,51 @@ export interface DocConfig {
 export interface XanoscriptDocsArgs {
   topic?: string;
   file_path?: string;
-  mode?: "full" | "quick_reference";
+  mode?: "full" | "quick_reference" | "index";
   exclude_topics?: string[];
 }
 
 // =============================================================================
-// Documentation Configuration
+// Documentation Configuration (loaded from docs_index.json)
 // =============================================================================
 
-export const XANOSCRIPT_DOCS_V2: Record<string, DocConfig> = {
-  readme: {
-    file: "README.md",
-    applyTo: [],
-    description: "XanoScript overview, workspace structure, and quick reference",
-  },
-  essentials: {
-    file: "essentials.md",
-    applyTo: ["**/*.xs"],
-    description: "Common patterns, quick reference, and common mistakes to avoid",
-  },
-  syntax: {
-    file: "syntax.md",
-    applyTo: ["**/*.xs"],
-    description: "Expressions, operators, and filters for all XanoScript code",
-  },
-  "syntax/string-filters": {
-    file: "syntax/string-filters.md",
-    applyTo: [],
-    description: "String filters, regex, encoding, security filters, text functions",
-  },
-  "syntax/array-filters": {
-    file: "syntax/array-filters.md",
-    applyTo: [],
-    description: "Array filters, functional operations, and array functions",
-  },
-  "syntax/functions": {
-    file: "syntax/functions.md",
-    applyTo: [],
-    description: "Math filters/functions, object functions, bitwise operations",
-  },
-  types: {
-    file: "types.md",
-    applyTo: ["functions/**/*.xs", "apis/**/*.xs", "tools/**/*.xs", "agents/**/*.xs"],
-    description: "Data types, input blocks, and validation",
-  },
-  tables: {
-    file: "tables.md",
-    applyTo: ["tables/*.xs"],
-    description: "Database schema definitions with indexes and relationships",
-  },
-  functions: {
-    file: "functions.md",
-    applyTo: ["functions/**/*.xs"],
-    description: "Reusable function stacks with inputs and responses",
-  },
-  apis: {
-    file: "apis.md",
-    applyTo: ["apis/**/*.xs"],
-    description: "HTTP endpoint definitions with authentication and CRUD patterns",
-  },
-  tasks: {
-    file: "tasks.md",
-    applyTo: ["tasks/*.xs"],
-    description: "Scheduled and cron jobs",
-  },
-  triggers: {
-    file: "triggers.md",
-    applyTo: ["triggers/**/*.xs"],
-    description: "Event-driven handlers (table, realtime, workspace, agent, MCP)",
-  },
-  database: {
-    file: "database.md",
-    applyTo: ["functions/**/*.xs", "apis/**/*.xs", "tasks/*.xs", "tools/**/*.xs"],
-    description: "All db.* operations: query, get, add, edit, patch, delete",
-  },
-  agents: {
-    file: "agents.md",
-    applyTo: ["agents/**/*.xs"],
-    description: "AI agent configuration with LLM providers and tools",
-  },
-  tools: {
-    file: "tools.md",
-    applyTo: ["tools/**/*.xs"],
-    description: "AI tools for agents and MCP servers",
-  },
-  "mcp-servers": {
-    file: "mcp-servers.md",
-    applyTo: ["mcp_servers/**/*.xs"],
-    description: "MCP server definitions exposing tools",
-  },
-  "unit-testing": {
-    file: "unit-testing.md",
-    applyTo: ["functions/**/*.xs", "apis/**/*.xs", "middleware/**/*.xs"],
-    description: "Unit tests, mocks, and assertions within functions, APIs, and middleware",
-  },
-  "workflow-tests": {
-    file: "workflow-tests.md",
-    applyTo: ["workflow_test/**/*.xs"],
-    description: "End-to-end workflow tests with data source selection and tags",
-  },
-  integrations: {
-    file: "integrations.md",
-    applyTo: [],
-    description: "External service integrations index - see sub-topics for details",
-  },
-  "integrations/cloud-storage": {
-    file: "integrations/cloud-storage.md",
-    applyTo: [],
-    description: "AWS S3, Azure Blob, and GCP Storage operations",
-  },
-  "integrations/search": {
-    file: "integrations/search.md",
-    applyTo: [],
-    description: "Elasticsearch, OpenSearch, and Algolia search operations",
-  },
-  "integrations/redis": {
-    file: "integrations/redis.md",
-    applyTo: [],
-    description: "Redis caching, rate limiting, and queue operations",
-  },
-  "integrations/external-apis": {
-    file: "integrations/external-apis.md",
-    applyTo: [],
-    description: "HTTP requests with api.request patterns",
-  },
-  "integrations/utilities": {
-    file: "integrations/utilities.md",
-    applyTo: [],
-    description: "Local storage, email, zip, and Lambda utilities",
-  },
-  frontend: {
-    file: "frontend.md",
-    applyTo: ["static/**/*"],
-    description: "Static frontend development and deployment",
-  },
-  run: {
-    file: "run.md",
-    applyTo: ["run/**/*.xs"],
-    description: "Run job and service configurations for the Xano Job Runner",
-  },
-  addons: {
-    file: "addons.md",
-    applyTo: ["addons/*.xs"],
-    description: "Reusable subqueries for fetching related data",
-  },
-  debugging: {
-    file: "debugging.md",
-    applyTo: ["**/*.xs"],
-    description: "Logging, inspecting, and debugging XanoScript execution",
-  },
-  performance: {
-    file: "performance.md",
-    applyTo: ["functions/**/*.xs", "apis/**/*.xs"],
-    description: "Performance optimization best practices",
-  },
-  realtime: {
-    file: "realtime.md",
-    applyTo: ["triggers/**/*.xs"],
-    description: "Real-time channels and events for push updates",
-  },
-  schema: {
-    file: "schema.md",
-    applyTo: [],
-    description: "Runtime schema parsing and validation",
-  },
-  security: {
-    file: "security.md",
-    applyTo: ["functions/**/*.xs", "apis/**/*.xs"],
-    description: "Security best practices for authentication and authorization",
-  },
-  streaming: {
-    file: "streaming.md",
-    applyTo: [],
-    description: "Streaming data from files, requests, and responses",
-  },
-  middleware: {
-    file: "middleware.md",
-    applyTo: ["middleware/**/*.xs"],
-    description: "Request/response interceptors for functions, queries, tasks, and tools",
-  },
-  branch: {
-    file: "branch.md",
-    applyTo: ["branch.xs"],
-    description: "Branch-level settings: middleware, history retention, visual styling",
-  },
-  workspace: {
-    file: "workspace.md",
-    applyTo: ["workspace/**/*.xs"],
-    description: "Workspace-level settings: environment variables, preferences, realtime",
-  },
-};
+function buildDocsConfig(): Record<string, DocConfig> {
+  const config: Record<string, DocConfig> = {};
+  for (const [key, topic] of Object.entries(docsIndex.topics)) {
+    config[key] = {
+      file: topic.file,
+      applyTo: topic.applyTo,
+      description: topic.description,
+    };
+  }
+  return config;
+}
+
+export const XANOSCRIPT_DOCS_V2: Record<string, DocConfig> = buildDocsConfig();
+
+// =============================================================================
+// Content Cache
+// =============================================================================
+
+const _fileCache = new Map<string, string>();
+let _versionCache: { path: string; version: string } | null = null;
+
+/**
+ * Clear all cached documentation content and version data.
+ * Useful for testing or when docs files change at runtime.
+ */
+export function clearDocsCache(): void {
+  _fileCache.clear();
+  _versionCache = null;
+}
+
+function cachedReadFile(filePath: string): string {
+  const cached = _fileCache.get(filePath);
+  if (cached !== undefined) return cached;
+  const content = readFileSync(filePath, "utf-8");
+  _fileCache.set(filePath, content);
+  return content;
+}
 
 // =============================================================================
 // Core Functions
@@ -268,9 +124,14 @@ export function extractQuickReference(content: string, topic: string): string {
  * Get the documentation version from the version.json file
  */
 export function getXanoscriptDocsVersion(docsPath: string): string {
+  if (_versionCache && _versionCache.path === docsPath) {
+    return _versionCache.version;
+  }
   try {
-    const versionFile = readFileSync(join(docsPath, "version.json"), "utf-8");
-    return JSON.parse(versionFile).version || "unknown";
+    const versionFile = cachedReadFile(join(docsPath, "version.json"));
+    const version = JSON.parse(versionFile).version || "unknown";
+    _versionCache = { path: docsPath, version };
+    return version;
   } catch {
     return "unknown";
   }
@@ -283,14 +144,41 @@ export function readXanoscriptDocsV2(
   docsPath: string,
   args?: XanoscriptDocsArgs
 ): string {
+  const version = getXanoscriptDocsVersion(docsPath);
+
+  // Index mode: return compact topic listing with byte sizes
+  if (args?.mode === "index") {
+    const rows = Object.entries(XANOSCRIPT_DOCS_V2).map(([name, config]) => {
+      let size: number;
+      try {
+        size = cachedReadFile(join(docsPath, config.file)).length;
+      } catch {
+        size = 0;
+      }
+      const sizeKb = (size / 1024).toFixed(1);
+      return `| ${name} | ${config.description} | ${sizeKb} KB |`;
+    });
+    return [
+      `# XanoScript Documentation Index`,
+      ``,
+      `Version: ${version}`,
+      `Topics: ${rows.length}`,
+      ``,
+      `| Topic | Description | Size |`,
+      `|-------|-------------|------|`,
+      ...rows,
+      ``,
+      `Use topic='<name>' to load a specific topic. Use mode='quick_reference' for compact output.`,
+    ].join("\n");
+  }
+
   // Default to quick_reference for file_path mode (loads many topics),
   // full for topic mode (loads single topic)
   const mode = args?.mode || (args?.file_path ? "quick_reference" : "full");
-  const version = getXanoscriptDocsVersion(docsPath);
 
   // Default: return README
   if (!args?.topic && !args?.file_path) {
-    const readme = readFileSync(join(docsPath, "README.md"), "utf-8");
+    const readme = cachedReadFile(join(docsPath, "README.md"));
     return `${readme}\n\n---\nDocumentation version: ${version}`;
   }
 
@@ -311,7 +199,7 @@ export function readXanoscriptDocsV2(
 
     const docs = topics.map((t) => {
       const config = XANOSCRIPT_DOCS_V2[t];
-      const content = readFileSync(join(docsPath, config.file), "utf-8");
+      const content = cachedReadFile(join(docsPath, config.file));
       return mode === "quick_reference"
         ? extractQuickReference(content, t)
         : content;
@@ -331,13 +219,61 @@ export function readXanoscriptDocsV2(
     );
   }
 
-  const content = readFileSync(join(docsPath, config.file), "utf-8");
+  const content = cachedReadFile(join(docsPath, config.file));
   const doc = mode === "quick_reference"
     ? extractQuickReference(content, args!.topic!)
     : content;
 
   return `${doc}\n\n---\nDocumentation version: ${version}`;
 }
+
+// =============================================================================
+// Structured Documentation Access
+// =============================================================================
+
+export interface TopicDoc {
+  topic: string;
+  content: string;
+}
+
+/**
+ * Read documentation as structured per-topic entries for file_path mode.
+ * Returns each matched topic as a separate object for multi-content MCP responses.
+ */
+export function readXanoscriptDocsStructured(
+  docsPath: string,
+  args: XanoscriptDocsArgs & { file_path: string }
+): TopicDoc[] {
+  const mode = args.mode || "quick_reference";
+
+  let topics = getDocsForFilePath(args.file_path);
+
+  if (args.exclude_topics && args.exclude_topics.length > 0) {
+    topics = topics.filter((t) => !args.exclude_topics!.includes(t));
+  }
+
+  if (topics.length === 0) {
+    throw new Error(
+      `No documentation found for file pattern: ${args.file_path}\n\nAvailable topics: ${Object.keys(XANOSCRIPT_DOCS_V2).join(", ")}`
+    );
+  }
+
+  return topics.map((t) => {
+    const config = XANOSCRIPT_DOCS_V2[t];
+    const content = cachedReadFile(join(docsPath, config.file));
+    return {
+      topic: t,
+      content:
+        mode === "quick_reference"
+          ? extractQuickReference(content, t)
+          : content,
+    };
+  });
+}
+
+// =============================================================================
+// Topic Metadata
+// =============================================================================
 
 /**
  * Get available topic names

--- a/src/xanoscript_docs/docs_index.json
+++ b/src/xanoscript_docs/docs_index.json
@@ -3,154 +3,225 @@
   "description": "Machine-readable index for XanoScript documentation",
 
   "topics": {
+    "readme": {
+      "file": "README.md",
+      "description": "XanoScript overview, workspace structure, and quick reference",
+      "applyTo": [],
+      "aliases": ["overview", "intro", "index"]
+    },
     "essentials": {
       "file": "essentials.md",
-      "purpose": "Common patterns, quick reference, and mistakes to avoid",
+      "description": "Common patterns, quick reference, and common mistakes to avoid",
+      "applyTo": ["**/*.xs"],
       "priority": 1,
       "aliases": ["quick", "common", "basics", "start", "cheatsheet", "quickstart", "patterns", "mistakes"]
     },
     "syntax": {
       "file": "syntax.md",
-      "purpose": "Operators, core filters, expressions, error handling",
+      "description": "Expressions, operators, and filters for all XanoScript code",
+      "applyTo": ["**/*.xs"],
       "priority": 2,
       "aliases": ["filters", "operators", "expressions"]
     },
     "syntax/string-filters": {
       "file": "syntax/string-filters.md",
-      "purpose": "String filters, regex, encoding, security filters, text functions",
+      "description": "String filters, regex, encoding, security filters, text functions",
+      "applyTo": [],
       "aliases": ["string", "regex", "encoding", "security-filters"]
     },
     "syntax/array-filters": {
       "file": "syntax/array-filters.md",
-      "purpose": "Array filters, functional operations, array functions",
+      "description": "Array filters, functional operations, and array functions",
+      "applyTo": [],
       "aliases": ["array", "map", "filter", "reduce", "sort"]
     },
     "syntax/functions": {
       "file": "syntax/functions.md",
-      "purpose": "Math filters/functions, object functions, bitwise operations",
+      "description": "Math filters/functions, object functions, bitwise operations",
+      "applyTo": [],
       "aliases": ["math", "object", "bitwise"]
     },
     "types": {
       "file": "types.md",
-      "purpose": "Data types, validation, input blocks",
+      "description": "Data types, input blocks, and validation",
+      "applyTo": ["functions/**/*.xs", "apis/**/*.xs", "tools/**/*.xs", "agents/**/*.xs"],
       "priority": 4,
       "aliases": ["validation", "input", "data-types"]
     },
-    "database": {
-      "file": "database.md",
-      "purpose": "All db.* operations",
-      "priority": 5,
-      "aliases": ["db", "crud", "query", "sql"]
-    },
     "tables": {
       "file": "tables.md",
-      "purpose": "Table schema definitions",
+      "description": "Database schema definitions with indexes and relationships",
+      "applyTo": ["tables/*.xs"],
       "aliases": ["schema", "fields", "indexes"]
-    },
-    "apis": {
-      "file": "apis.md",
-      "purpose": "HTTP endpoint definitions",
-      "aliases": ["endpoints", "http", "rest", "query"]
     },
     "functions": {
       "file": "functions.md",
-      "purpose": "Reusable function stacks",
+      "description": "Reusable function stacks with inputs and responses",
+      "applyTo": ["functions/**/*.xs"],
       "aliases": ["fn", "reusable", "stack"]
+    },
+    "apis": {
+      "file": "apis.md",
+      "description": "HTTP endpoint definitions with authentication and CRUD patterns",
+      "applyTo": ["apis/**/*.xs"],
+      "aliases": ["endpoints", "http", "rest", "query"]
+    },
+    "tasks": {
+      "file": "tasks.md",
+      "description": "Scheduled and cron jobs",
+      "applyTo": ["tasks/*.xs"],
+      "aliases": ["scheduled", "jobs", "cron"]
     },
     "triggers": {
       "file": "triggers.md",
-      "purpose": "Event-driven handlers",
+      "description": "Event-driven handlers (table, realtime, workspace, agent, MCP)",
+      "applyTo": ["triggers/**/*.xs"],
       "aliases": ["events", "hooks", "handlers"]
+    },
+    "database": {
+      "file": "database.md",
+      "description": "All db.* operations: query, get, add, edit, patch, delete",
+      "applyTo": ["functions/**/*.xs", "apis/**/*.xs", "tasks/*.xs", "tools/**/*.xs"],
+      "priority": 5,
+      "aliases": ["db", "crud", "query", "sql"]
     },
     "agents": {
       "file": "agents.md",
-      "purpose": "AI agent configuration",
+      "description": "AI agent configuration with LLM providers and tools",
+      "applyTo": ["agents/**/*.xs"],
       "aliases": ["ai", "llm", "chatbot"]
     },
     "tools": {
       "file": "tools.md",
-      "purpose": "AI tools for agents",
+      "description": "AI tools for agents and MCP servers",
+      "applyTo": ["tools/**/*.xs"],
       "aliases": ["ai-tools", "agent-tools"]
-    },
-    "integrations": {
-      "file": "integrations.md",
-      "purpose": "External service integrations (index)",
-      "aliases": ["external", "services", "cloud"]
-    },
-    "integrations/cloud-storage": {
-      "file": "integrations/cloud-storage.md",
-      "purpose": "AWS S3, Azure Blob, GCP Storage",
-      "aliases": ["s3", "azure", "gcp", "files", "upload"]
-    },
-    "integrations/search": {
-      "file": "integrations/search.md",
-      "purpose": "Elasticsearch, Algolia",
-      "aliases": ["elasticsearch", "algolia", "full-text"]
-    },
-    "integrations/redis": {
-      "file": "integrations/redis.md",
-      "purpose": "Caching, rate limiting, queues",
-      "aliases": ["cache", "rate-limit", "queue"]
-    },
-    "integrations/external-apis": {
-      "file": "integrations/external-apis.md",
-      "purpose": "api.request patterns",
-      "aliases": ["http", "api", "request", "fetch"]
-    },
-    "integrations/utilities": {
-      "file": "integrations/utilities.md",
-      "purpose": "Email, Zip, Lambda",
-      "aliases": ["email", "zip", "lambda", "archive"]
-    },
-    "security": {
-      "file": "security.md",
-      "purpose": "Authentication, authorization, security patterns",
-      "aliases": ["auth", "authorization", "permissions"]
-    },
-    "performance": {
-      "file": "performance.md",
-      "purpose": "Optimization best practices",
-      "aliases": ["optimization", "speed", "caching"]
     },
     "mcp-servers": {
       "file": "mcp-servers.md",
-      "purpose": "MCP server configuration",
+      "description": "MCP server definitions exposing tools",
+      "applyTo": ["mcp_servers/**/*.xs"],
       "aliases": ["mcp", "model-context-protocol"]
-    },
-    "tasks": {
-      "file": "tasks.md",
-      "purpose": "Scheduled job definitions",
-      "aliases": ["scheduled", "jobs", "cron"]
-    },
-    "streaming": {
-      "file": "streaming.md",
-      "purpose": "Streaming data handling",
-      "aliases": ["stream", "large-files"]
-    },
-    "realtime": {
-      "file": "realtime.md",
-      "purpose": "Real-time channel configuration",
-      "aliases": ["websocket", "channels", "pubsub"]
-    },
-    "middleware": {
-      "file": "middleware.md",
-      "purpose": "Request interceptors",
-      "aliases": ["interceptors", "hooks"]
     },
     "unit-testing": {
       "file": "unit-testing.md",
-      "purpose": "Unit tests, mocks, and assertions",
+      "description": "Unit tests, mocks, and assertions within functions, APIs, and middleware",
+      "applyTo": ["functions/**/*.xs", "apis/**/*.xs", "middleware/**/*.xs"],
       "aliases": ["tests", "unit-tests", "mocks", "assertions"]
     },
     "workflow-tests": {
       "file": "workflow-tests.md",
-      "purpose": "End-to-end workflow tests",
+      "description": "End-to-end workflow tests with data source selection and tags",
+      "applyTo": ["workflow_test/**/*.xs"],
       "aliases": ["e2e", "workflow", "integration-tests"]
+    },
+    "integrations": {
+      "file": "integrations.md",
+      "description": "External service integrations index - see sub-topics for details",
+      "applyTo": [],
+      "aliases": ["external", "services", "cloud"]
+    },
+    "integrations/cloud-storage": {
+      "file": "integrations/cloud-storage.md",
+      "description": "AWS S3, Azure Blob, and GCP Storage operations",
+      "applyTo": [],
+      "aliases": ["s3", "azure", "gcp", "files", "upload"]
+    },
+    "integrations/search": {
+      "file": "integrations/search.md",
+      "description": "Elasticsearch, OpenSearch, and Algolia search operations",
+      "applyTo": [],
+      "aliases": ["elasticsearch", "algolia", "full-text"]
+    },
+    "integrations/redis": {
+      "file": "integrations/redis.md",
+      "description": "Redis caching, rate limiting, and queue operations",
+      "applyTo": [],
+      "aliases": ["cache", "rate-limit", "queue"]
+    },
+    "integrations/external-apis": {
+      "file": "integrations/external-apis.md",
+      "description": "HTTP requests with api.request patterns",
+      "applyTo": [],
+      "aliases": ["http", "api", "request", "fetch"]
+    },
+    "integrations/utilities": {
+      "file": "integrations/utilities.md",
+      "description": "Local storage, email, zip, and Lambda utilities",
+      "applyTo": [],
+      "aliases": ["email", "zip", "lambda", "archive"]
+    },
+    "frontend": {
+      "file": "frontend.md",
+      "description": "Static frontend development and deployment",
+      "applyTo": ["static/**/*"],
+      "aliases": ["static", "html", "css", "web"]
+    },
+    "run": {
+      "file": "run.md",
+      "description": "Run job and service configurations for the Xano Job Runner",
+      "applyTo": ["run/**/*.xs"],
+      "aliases": ["jobs", "runner", "services"]
+    },
+    "addons": {
+      "file": "addons.md",
+      "description": "Reusable subqueries for fetching related data",
+      "applyTo": ["addons/*.xs"],
+      "aliases": ["subqueries", "relations"]
     },
     "debugging": {
       "file": "debugging.md",
-      "purpose": "Logging and debugging",
+      "description": "Logging, inspecting, and debugging XanoScript execution",
+      "applyTo": ["**/*.xs"],
       "aliases": ["logs", "debug", "trace"]
+    },
+    "performance": {
+      "file": "performance.md",
+      "description": "Performance optimization best practices",
+      "applyTo": ["functions/**/*.xs", "apis/**/*.xs"],
+      "aliases": ["optimization", "speed", "caching"]
+    },
+    "realtime": {
+      "file": "realtime.md",
+      "description": "Real-time channels and events for push updates",
+      "applyTo": ["triggers/**/*.xs"],
+      "aliases": ["websocket", "channels", "pubsub"]
+    },
+    "schema": {
+      "file": "schema.md",
+      "description": "Runtime schema parsing and validation",
+      "applyTo": [],
+      "aliases": ["runtime-schema", "parsing"]
+    },
+    "security": {
+      "file": "security.md",
+      "description": "Security best practices for authentication and authorization",
+      "applyTo": ["functions/**/*.xs", "apis/**/*.xs"],
+      "aliases": ["auth", "authorization", "permissions"]
+    },
+    "streaming": {
+      "file": "streaming.md",
+      "description": "Streaming data from files, requests, and responses",
+      "applyTo": [],
+      "aliases": ["stream", "large-files"]
+    },
+    "middleware": {
+      "file": "middleware.md",
+      "description": "Request/response interceptors for functions, queries, tasks, and tools",
+      "applyTo": ["middleware/**/*.xs"],
+      "aliases": ["interceptors", "hooks"]
+    },
+    "branch": {
+      "file": "branch.md",
+      "description": "Branch-level settings: middleware, history retention, visual styling",
+      "applyTo": ["branch.xs"],
+      "aliases": ["settings", "config"]
+    },
+    "workspace": {
+      "file": "workspace.md",
+      "description": "Workspace-level settings: environment variables, preferences, realtime",
+      "applyTo": ["workspace/**/*.xs"],
+      "aliases": ["env", "environment", "preferences"]
     }
   },
 


### PR DESCRIPTION
## Summary

- **Iteration 5 (Architecture & Code Quality):** Unified path resolution, added content caching, expanded test coverage (2 new test files, 184 total tests), replaced unsafe type casts with Zod runtime validation, made `ToolResult` a discriminated union, and switched to `docs_index.json` as the single source of truth for topic configuration
- **Iteration 6 (Advanced Features):** Added `mode='index'` for compact topic discovery (~1KB), structured multi-content responses (file_path mode returns separate MCP content blocks per topic), and `outputSchema` + `structuredContent` on all 5 tool definitions

## Changes

### 5.1 Unified path resolution
- Removed duplicate `getXanoscriptDocsPath()` from `src/index.ts`, now imports shared function from `src/tools/xanoscript_docs.ts`

### 5.2 Content caching
- Added `Map<string, string>` file cache and version cache in `src/xanoscript.ts`
- `cachedReadFile()` and `clearDocsCache()` for efficient doc reads

### 5.3 Expanded test coverage
- New `src/tools/index.test.ts` (62 tests): handleTool dispatch, toMcpResponse, toolDefinitions, integration tests for all 35 topic files
- New `src/tools/xanoscript_docs.test.ts` (28 tests): path resolution, standalone function, ToolResult wrapper, structured output, structuredContent

### 5.4 Runtime argument validation
- `ToolResult` changed to discriminated union: `{ success: true; data: string | string[] } | { success: false; error: string }`
- Zod schemas replace `as unknown as` casts in `handleTool` dispatcher

### 5.5 docs_index.json as source of truth
- Enriched `docs_index.json` with all 35 topics including `applyTo` and `description` fields
- `buildDocsConfig()` derives `XANOSCRIPT_DOCS_V2` from JSON import at startup

### 6.1 Compact topic index mode
- `mode: "index"` returns markdown table with topic names, descriptions, and KB sizes (~1KB total)

### 6.4 Structured multi-content responses
- `file_path` mode returns `string[]` (header + N topic blocks) instead of concatenated string
- `toMcpResponse` maps arrays to multiple `{ type: "text" }` content blocks
- `readXanoscriptDocsStructured()` added for per-topic access
- Library `xanoscriptDocs()` now returns optional `topics: TopicDoc[]`

### 6.5 outputSchema on all tools
- Added `outputSchema` (JSON Schema) to all 5 tool definitions
- Extended `ToolResult` with optional `structuredContent`
- All tool functions populate `structuredContent` in success responses

## Test plan

- [x] All 184 tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Existing behavior preserved (topic mode, file_path mode, README default)
- [ ] Verify MCP clients receive multiple content blocks for file_path requests
- [ ] Verify structuredContent is accessible to clients supporting outputSchema


🤖 Generated with [Claude Code](https://claude.com/claude-code)