### PR TITLE
Bump @xano/xanoscript-language-server to 11.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.23",
+  "version": "1.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.23",
+      "version": "1.0.57",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@xano/xanoscript-language-server": "^11.6.5",
+        "@xano/xanoscript-language-server": "^11.8.2",
         "minimatch": "^10.1.2"
       },
       "bin": {
@@ -1092,9 +1092,9 @@
       }
     },
     "node_modules/@xano/xanoscript-language-server": {
-      "version": "11.6.5",
-      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-11.6.5.tgz",
-      "integrity": "sha512-h2yV/LdY7HjI0tFit9qghNQVlcpujUKwWgJSGzl/ZEBAHYtYlf38IY/h+9HhzIMHoPMpAM4UqMZOVAkMfrXh8g==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-11.8.2.tgz",
+      "integrity": "sha512-UU4VZCLWxZXYefsF8cBaFVxGGYWlCn2onlDmaT8wWEoz4p0riJ5umZ3xHlicjK/UcrcWoShfI5rjXXMU8+n3Ww==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",
@@ -59,7 +59,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@xano/xanoscript-language-server": "^11.6.5",
+    "@xano/xanoscript-language-server": "^11.8.2",
     "minimatch": "^10.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Update `@xano/xanoscript-language-server` from `^11.6.5` to `^11.8.2`
- Bump package version from `1.0.57` to `1.0.58`

## Test plan
- [x] All 184 tests pass across 6 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)