### PR TITLE
Fix broken topic references and add Related Topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -193,6 +193,9 @@ Use `xanoscript_docs({ tier: "survival" })` or `xanoscript_docs({ tier: "working
 | ------------ | ---------------------------------------------------- | ------------ |
 | `essentials` | Common patterns, quick examples, mistakes to avoid   | Patterns, Common Mistakes |
 | `syntax`     | Expressions, operators, filters, system variables    | Filters, Error Handling |
+| `syntax/string-filters` | String manipulation filters                 | Case, Trim, Split, Replace |
+| `syntax/array-filters`  | Array manipulation filters                  | Map, Filter, Sort, Group |
+| `syntax/functions`      | Built-in functions                          | Math, Date, Crypto, JSON |
 | `types`      | Data types, validation, input blocks                 | Validation Filters, Input Blocks |
 | `functions`  | Reusable function stacks, async, loops               | Loops, Async Patterns |
 | `schema`     | Runtime schema parsing and validation                | parse.object, parse.array |
@@ -227,7 +230,7 @@ Use `xanoscript_docs({ tier: "survival" })` or `xanoscript_docs({ tier: "working
 
 | Topic          | Description                                       | Sub-topics |
 | -------------- | ------------------------------------------------- | ---------- |
-| `integrations` | Cloud storage, Redis, security, and external APIs | cloud-storage, search, redis, external-apis, utilities |
+| `integrations` | Cloud storage, Redis, security, and external APIs | integrations/cloud-storage, integrations/search, integrations/redis, integrations/external-apis, integrations/utilities |
 
 ### Configuration
 

--- a/src/xanoscript_docs/branch.md
+++ b/src/xanoscript_docs/branch.md
@@ -236,3 +236,13 @@ project/
 1. **Use descriptive colors** - Green for production, blue for development, yellow for staging
 2. **Limit production history** - Excessive history impacts performance and storage
 3. **Apply security middleware in production** - Rate limiting, auth checks, audit logging
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `workspace` | Workspace-level configuration |
+| `middleware` | Request/response interceptors |
+| `security` | Authentication and rate limiting |

--- a/src/xanoscript_docs/debugging.md
+++ b/src/xanoscript_docs/debugging.md
@@ -77,3 +77,13 @@ View past request executions in the Xano dashboard:
 
 1. **Remove debug.stop in production** - Causes execution to halt
 2. **Don't log sensitive data** - Passwords, tokens, PII
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `performance` | Performance profiling and optimization |
+| `unit-testing` | Unit testing functions |
+| `workflow-tests` | End-to-end workflow testing |

--- a/src/xanoscript_docs/functions.md
+++ b/src/xanoscript_docs/functions.md
@@ -472,4 +472,4 @@ Explore more with `xanoscript_docs({ topic: "<topic>" })`:
 | `syntax` | Expressions, operators, and control flow |
 | `essentials` | Common patterns and examples |
 | `database` | Database operations in function stacks |
-| `testing` | Unit testing functions |
+| `unit-testing` | Unit testing functions |

--- a/src/xanoscript_docs/middleware.md
+++ b/src/xanoscript_docs/middleware.md
@@ -304,3 +304,14 @@ branch "production" {
 1. **Keep middleware focused** - Each middleware should do one thing well
 2. **Use appropriate exception policies** - Critical for security, silent for optional enrichment
 3. **Consider performance** - Middleware runs on every request; log even silent failures
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `branch` | Branch-level middleware configuration |
+| `security` | Authentication and authorization patterns |
+| `apis` | API endpoint request/response lifecycle |
+| `performance` | Performance optimization strategies |

--- a/src/xanoscript_docs/realtime.md
+++ b/src/xanoscript_docs/realtime.md
@@ -295,3 +295,13 @@ Clients subscribe to channels client-side. Server controls what events to send. 
 1. **Use channel namespacing** - `type:id` format for clarity
 2. **Keep payloads small** - Send IDs, let client fetch details
 3. **Validate before broadcast** - Don't trust client event data
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `workspace` | Realtime configuration settings |
+| `security` | Authorization patterns for channels |
+| `frontend` | Client-side realtime integration |

--- a/src/xanoscript_docs/schema.md
+++ b/src/xanoscript_docs/schema.md
@@ -288,3 +288,13 @@ try_catch {
 1. **Define schemas upfront** - Use input blocks when structure is known
 2. **Use schema.parse for dynamic data** - External APIs, user-generated content
 3. **Validate at boundaries** - Parse external input, trust internal data; provide clear error messages
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `types` | Data types and input validation |
+| `integrations/external-apis` | Parsing external API responses |
+| `syntax` | Expressions and filters |

--- a/src/xanoscript_docs/survival.md
+++ b/src/xanoscript_docs/survival.md
@@ -158,4 +158,4 @@ input {
 
 ### Available Topics
 
-essentials, syntax, types, database, functions, apis, tables, tasks, triggers, agents, tools, mcp-servers, security, performance, debugging, unit-testing, workflow-tests, middleware, addons, realtime, streaming, schema, integrations, workspace, branch, run, frontend
+survival, working, readme, essentials, syntax, syntax/string-filters, syntax/array-filters, syntax/functions, types, database, functions, apis, tables, tasks, triggers, agents, tools, mcp-servers, security, performance, debugging, unit-testing, workflow-tests, middleware, addons, realtime, streaming, schema, integrations, integrations/cloud-storage, integrations/search, integrations/redis, integrations/external-apis, integrations/utilities, workspace, branch, run, frontend

--- a/src/xanoscript_docs/workspace.md
+++ b/src/xanoscript_docs/workspace.md
@@ -207,3 +207,13 @@ These variables are automatically available without configuration:
 1. **Never commit secrets** - Use environment variables for API keys and credentials
 2. **Use descriptive names** - Environment variable names should be self-documenting
 3. **Enable performance tracking** - Helps identify bottlenecks in production
+
+---
+
+## Related Topics
+
+| Topic | Description |
+|-------|-------------|
+| `branch` | Branch-level configuration |
+| `realtime` | Realtime channel configuration |
+| `security` | Environment variable security practices |


### PR DESCRIPTION
## Summary
- Fixed bare topic names (`redis`, `testing`) that caused "Unknown topic" errors — now use fully qualified paths (`integrations/redis`, `unit-testing`)
- Added all missing topics to survival.md's Available Topics list (was missing 6 sub-topics)
- Added syntax sub-topics to README Core Language table for discoverability
- Added Related Topics sections to 6 docs that were missing them (middleware, branch, workspace, schema, realtime, debugging)
- Bumped version to 1.0.60

## Test plan
- [ ] Verify `xanoscript_docs({ topic: "redis" })` error no longer occurs when AI models parse the docs
- [ ] Spot-check Related Topics links in updated docs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)