### PR TITLE
Add CLI docs for new commands and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,12 +500,19 @@ Use this tool to understand CLI commands for local development, code synchroniza
 | Topic | Description |
 |-------|-------------|
 | `start` | Getting started with the CLI - installation and setup |
+| `auth` | Browser-based OAuth authentication |
 | `profile` | Profile management - credentials and multi-environment setup |
-| `workspace` | Workspace operations - pull/push code sync |
+| `workspace` | Workspace operations - pull/push code sync, git integration |
 | `branch` | Branch management - list, switch, create, and delete branches |
 | `function` | Function management - list, get, create, edit |
+| `release` | Release management - create, export, import, pull, push |
+| `tenant` | Tenant management - CRUD, deployments, env vars, backups, clusters |
+| `unit_test` | Unit test management - list and run unit tests |
+| `workflow_test` | Workflow test management - list, run, and manage workflow tests |
 | `run` | Run API commands - execute code, manage projects/sessions |
+| `platform` | Platform management - list and view platform versions |
 | `static_host` | Static hosting - deploy frontend builds |
+| `update` | Update the CLI to the latest version |
 | `integration` | CLI + Meta API integration guide - when to use each |
 
 **Examples:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.57",
+  "version": "1.0.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.57",
+      "version": "1.0.61",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -9,26 +9,40 @@ import type { TopicDoc, DetailLevel, CliDocsArgs } from "./types.js";
 import { formatDocumentation } from "./format.js";
 
 // Import all topic documentation
+import { authDoc } from "./topics/auth.js";
 import { startDoc } from "./topics/start.js";
 import { profileDoc } from "./topics/profile.js";
 import { workspaceDoc } from "./topics/workspace.js";
 import { branchDoc } from "./topics/branch.js";
 import { functionDoc } from "./topics/function.js";
+import { releaseDoc } from "./topics/release.js";
+import { tenantDoc } from "./topics/tenant.js";
+import { unitTestDoc } from "./topics/unit_test.js";
+import { workflowTestDoc } from "./topics/workflow_test.js";
 import { runDoc } from "./topics/run.js";
+import { platformDoc } from "./topics/platform.js";
 import { staticHostDoc } from "./topics/static_host.js";
+import { updateDoc } from "./topics/update.js";
 import { integrationDoc } from "./topics/integration.js";
 
 /**
  * All available documentation topics
  */
 export const topics: Record<string, TopicDoc> = {
+  auth: authDoc,
   start: startDoc,
   profile: profileDoc,
   workspace: workspaceDoc,
   branch: branchDoc,
   function: functionDoc,
+  release: releaseDoc,
+  tenant: tenantDoc,
+  unit_test: unitTestDoc,
+  workflow_test: workflowTestDoc,
   run: runDoc,
+  platform: platformDoc,
   static_host: staticHostDoc,
+  update: updateDoc,
   integration: integrationDoc,
 };
 
@@ -82,8 +96,9 @@ ${getTopicDescriptions()}
 
 ## Usage
 - Start with "start" topic for installation and setup
+- Use "auth" or "profile" to understand authentication options
 - Use "integration" to understand when to use CLI vs Meta API
-- Use specific topics (profile, workspace, function, run) for command reference`,
+- Use specific topics for command reference (workspace, branch, release, tenant, function, run, etc.)`,
 
   inputSchema: {
     type: "object",

--- a/src/cli_docs/topics/auth.ts
+++ b/src/cli_docs/topics/auth.ts
@@ -1,0 +1,68 @@
+import type { TopicDoc } from "../types.js";
+
+export const authDoc: TopicDoc = {
+  topic: "auth",
+  title: "Xano CLI - Authentication",
+  description: `The \`auth\` command provides browser-based OAuth authentication for the Xano CLI. It opens your browser, lets you log in to your Xano account, and automatically creates a profile with your credentials.
+
+## How It Works
+
+1. CLI starts a local HTTP server on a random port
+2. Opens your browser to the Xano login page
+3. After login, Xano redirects back to the local server with your token
+4. CLI validates the token, lets you select instance/workspace/branch
+5. Saves the profile to \`~/.xano/credentials.yaml\`
+
+The authentication flow has a 5-minute timeout.`,
+
+  ai_hints: `**auth vs profile:wizard:**
+- \`xano auth\` - Browser-based OAuth login (recommended for interactive use)
+- \`xano profile:wizard\` - Token-based interactive setup (requires manually copying token)
+- \`xano profile:create\` - Non-interactive, requires all flags
+
+**When to suggest auth:**
+- User is setting up CLI for the first time
+- User doesn't have an access token handy
+- User prefers browser-based login
+
+**When to suggest profile:wizard instead:**
+- User already has an access token
+- User is in a headless/SSH environment without browser access
+- User needs non-interactive setup (CI/CD)`,
+
+  related_topics: ["profile", "start"],
+
+  commands: [
+    {
+      name: "auth",
+      description: "Authenticate with Xano via browser login. Opens your browser to log in and automatically creates a CLI profile.",
+      usage: "xano auth [options]",
+      flags: [
+        { name: "origin", type: "string", required: false, description: "Xano account origin URL (e.g., https://app.xano.com)" },
+        { name: "insecure", short: "k", type: "boolean", required: false, description: "Skip TLS certificate verification (for self-signed certs)" }
+      ],
+      examples: [
+        "xano auth",
+        "xano auth --origin https://app.xano.com",
+        "xano auth -k  # for self-signed certificates"
+      ]
+    }
+  ],
+
+  workflows: [
+    {
+      name: "First-Time Setup with Browser Login",
+      description: "Set up the CLI using browser-based authentication",
+      steps: [
+        "Install CLI: `npm install -g @xano/cli`",
+        "Run: `xano auth`",
+        "Log in via your browser when it opens",
+        "Select your instance, workspace, and branch",
+        "Verify: `xano profile:me`"
+      ],
+      example: `npm install -g @xano/cli
+xano auth
+xano profile:me`
+    }
+  ]
+};

--- a/src/cli_docs/topics/branch.ts
+++ b/src/cli_docs/topics/branch.ts
@@ -33,7 +33,7 @@ Branches are identified by their **label** (e.g., "v1", "dev", "staging"), not n
 - Pass via \`--workspace\` flag or configure in profile
 - Use \`xano workspace:list\` to find workspace IDs`,
 
-  related_topics: ["workspace", "profile", "integration"],
+  related_topics: ["workspace", "release", "profile", "integration"],
 
   commands: [
     {

--- a/src/cli_docs/topics/function.ts
+++ b/src/cli_docs/topics/function.ts
@@ -34,7 +34,8 @@ export const functionDoc: TopicDoc = {
         { name: "search", type: "string", required: false, description: "Search by name" },
         { name: "sort", type: "string", required: false, description: "Sort field" },
         { name: "order", type: "string", required: false, description: "Sort order: asc, desc" },
-        { name: "include_draft", type: "boolean", required: false, description: "Include draft versions" }
+        { name: "include_draft", type: "boolean", required: false, description: "Include draft versions" },
+        { name: "include_xanoscript", type: "boolean", required: false, description: "Include XanoScript source in output" }
       ],
       examples: [
         "xano function:list",
@@ -86,11 +87,16 @@ export const functionDoc: TopicDoc = {
       ],
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
-        { name: "file", short: "f", type: "string", required: false, description: "Path to .xs file with updated code" }
+        { name: "file", short: "f", type: "string", required: false, description: "Path to .xs file with updated code" },
+        { name: "stdin", type: "boolean", required: false, description: "Read updated code from stdin" },
+        { name: "edit", type: "boolean", required: false, description: "Open current code in $EDITOR before updating" },
+        { name: "no-publish", type: "boolean", required: false, description: "Save as draft without publishing" }
       ],
       examples: [
         "xano function:edit 145",
-        "xano function:edit 145 -f ./updated_function.xs"
+        "xano function:edit 145 -f ./updated_function.xs",
+        "xano function:edit 145 --edit",
+        "xano function:edit 145 --no-publish"
       ]
     }
   ],

--- a/src/cli_docs/topics/integration.ts
+++ b/src/cli_docs/topics/integration.ts
@@ -23,8 +23,13 @@ npm install -g @xano/cli
 | Local development | Yes | - |
 | Code sync (pull/push) | Yes | - |
 | Quick function edits | Yes | - |
+| Branch management | Yes | Yes |
+| Release management | Yes | Yes |
+| Tenant management | Yes | Yes |
+| Run unit/workflow tests | Yes | - |
 | Execute XanoScript | Yes | Yes (Run API) |
 | CI/CD automation | Both | Both |
+| Deploy static sites | Yes | - |
 | Programmatic management | - | Yes |
 | Create tables/schemas | - | Yes |
 | Manage API groups | - | Yes |
@@ -86,7 +91,7 @@ TOKEN=$(xano profile:token)
 curl -H "Authorization: Bearer $TOKEN" https://instance.xano.io/api:meta/workspace
 \`\`\``,
 
-  related_topics: ["start", "profile", "workspace"],
+  related_topics: ["start", "auth", "profile", "workspace", "release", "tenant"],
 
   workflows: [
     {

--- a/src/cli_docs/topics/platform.ts
+++ b/src/cli_docs/topics/platform.ts
@@ -1,0 +1,46 @@
+import type { TopicDoc } from "../types.js";
+
+export const platformDoc: TopicDoc = {
+  topic: "platform",
+  title: "Xano CLI - Platform Management",
+  description: `Platform commands let you view available Xano platform versions. Platforms define the runtime environment for tenants and can be deployed to tenants using \`tenant:deploy_platform\`.`,
+
+  ai_hints: `**Platforms are read-only in the CLI** - you can list and view them but not create/modify.
+
+**Use cases:**
+- Check available platform versions before deploying to a tenant
+- Get platform details (version, features, etc.)
+- Used with \`tenant:deploy_platform\` to update a tenant's runtime`,
+
+  related_topics: ["tenant"],
+
+  commands: [
+    {
+      name: "platform:list",
+      description: "List all available platform versions",
+      usage: "xano platform:list [options]",
+      flags: [
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano platform:list",
+        "xano platform:list -o json"
+      ]
+    },
+    {
+      name: "platform:get",
+      description: "Get details of a specific platform version",
+      usage: "xano platform:get <platform_id> [options]",
+      args: [
+        { name: "platform_id", required: true, description: "Platform ID" }
+      ],
+      flags: [
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano platform:get 5",
+        "xano platform:get 5 -o json"
+      ]
+    }
+  ]
+};

--- a/src/cli_docs/topics/profile.ts
+++ b/src/cli_docs/topics/profile.ts
@@ -41,20 +41,30 @@ default: production
 **Switching contexts:**
 - Use \`-p <profile>\` flag on any command
 - Or set \`XANO_PROFILE\` environment variable
-- Or use \`profile:set-default\` to change default`,
+- Or use \`profile:set\` to change default
 
-  related_topics: ["start", "integration"],
+**Alternative auth methods:**
+- \`xano auth\` - Browser-based OAuth login (no token needed)
+- \`xano profile:wizard\` - Interactive token-based setup
+- \`xano profile:create\` - Non-interactive (for CI/CD)`,
+
+  related_topics: ["auth", "start", "integration"],
 
   commands: [
     {
       name: "profile:wizard",
-      description: "Interactive setup wizard for creating a profile",
-      usage: "xano profile:wizard",
-      examples: ["xano profile:wizard"]
+      description: "Interactive setup wizard for creating a profile. Prompts for token, instance, workspace, and branch.",
+      usage: "xano profile:wizard [options]",
+      flags: [
+        { name: "name", short: "n", type: "string", required: false, description: "Profile name (prompted if not provided)" },
+        { name: "origin", short: "o", type: "string", required: false, description: "Xano account origin URL" },
+        { name: "insecure", short: "k", type: "boolean", required: false, description: "Skip TLS certificate verification" }
+      ],
+      examples: ["xano profile:wizard", "xano profile:wizard -n myprofile"]
     },
     {
       name: "profile:create",
-      description: "Create a new profile with explicit flags",
+      description: "Create a new profile with explicit flags (non-interactive)",
       usage: "xano profile:create <name> -i <instance_origin> -t <token> [options]",
       args: [
         { name: "name", required: true, description: "Profile name" }
@@ -62,13 +72,15 @@ default: production
       flags: [
         { name: "instance_origin", short: "i", type: "string", required: true, description: "Xano instance URL" },
         { name: "access_token", short: "t", type: "string", required: true, description: "Access token" },
+        { name: "account_origin", short: "a", type: "string", required: false, description: "Xano account origin URL" },
         { name: "workspace", short: "w", type: "string", required: false, description: "Default workspace ID" },
-        { name: "branch", short: "b", type: "string", required: false, description: "Default branch ID" },
-        { name: "project", short: "j", type: "string", required: false, description: "Default Run project ID" }
+        { name: "branch", short: "b", type: "string", required: false, description: "Default branch label" },
+        { name: "default", type: "boolean", required: false, description: "Set as the default profile" },
+        { name: "insecure", short: "k", type: "boolean", required: false, description: "Skip TLS certificate verification" }
       ],
       examples: [
         "xano profile:create production -i https://x8ki.xano.io -t mytoken123",
-        "xano profile:create staging -i https://x8ki.xano.io -t mytoken -w 1 -b 2"
+        "xano profile:create staging -i https://x8ki.xano.io -t mytoken -w 1 -b dev --default"
       ]
     },
     {
@@ -76,70 +88,93 @@ default: production
       description: "List all configured profiles",
       usage: "xano profile:list [--details]",
       flags: [
-        { name: "details", type: "boolean", required: false, description: "Show masked tokens and full config" }
+        { name: "details", short: "d", type: "boolean", required: false, description: "Show masked tokens, origins, workspace, branch, and insecure status" }
       ],
       examples: ["xano profile:list", "xano profile:list --details"]
     },
     {
       name: "profile:edit",
       description: "Edit an existing profile",
-      usage: "xano profile:edit <name> [options]",
+      usage: "xano profile:edit [name] [options]",
       args: [
-        { name: "name", required: true, description: "Profile name to edit" }
+        { name: "name", required: false, description: "Profile name to edit (uses default if not provided)" }
       ],
       flags: [
+        { name: "access_token", short: "t", type: "string", required: false, description: "Update access token" },
+        { name: "instance_origin", short: "i", type: "string", required: false, description: "Update instance URL" },
+        { name: "account_origin", short: "a", type: "string", required: false, description: "Update account origin URL" },
         { name: "workspace", short: "w", type: "string", required: false, description: "Set workspace ID" },
-        { name: "branch", short: "b", type: "string", required: false, description: "Set branch ID" },
-        { name: "project", short: "j", type: "string", required: false, description: "Set Run project ID" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Set branch label" },
+        { name: "insecure", type: "boolean", required: false, description: "Enable insecure mode for self-signed certs" },
         { name: "remove-workspace", type: "boolean", required: false, description: "Remove workspace setting" },
-        { name: "remove-branch", type: "boolean", required: false, description: "Remove branch setting" }
+        { name: "remove-branch", type: "boolean", required: false, description: "Remove branch setting" },
+        { name: "remove-insecure", type: "boolean", required: false, description: "Remove insecure setting" }
       ],
       examples: [
         "xano profile:edit production -w 2",
-        "xano profile:edit staging --remove-branch"
+        "xano profile:edit staging --remove-branch",
+        "xano profile:edit production -t new-token-here"
       ]
     },
     {
       name: "profile:delete",
-      description: "Delete a profile",
+      description: "Delete a profile. Auto-updates default if deleting the current default.",
       usage: "xano profile:delete <name> [--force]",
       args: [
         { name: "name", required: true, description: "Profile name to delete" }
       ],
       flags: [
-        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" }
+        { name: "force", short: "f", type: "boolean", required: false, description: "Skip confirmation prompt" }
       ],
       examples: ["xano profile:delete old-profile", "xano profile:delete test --force"]
     },
     {
-      name: "profile:set-default",
+      name: "profile:set",
       description: "Set the default profile",
-      usage: "xano profile:set-default <name>",
+      usage: "xano profile:set <name>",
       args: [
         { name: "name", required: true, description: "Profile to set as default" }
       ],
-      examples: ["xano profile:set-default production"]
+      examples: ["xano profile:set production"]
     },
     {
-      name: "profile:get-default",
-      description: "Show the current default profile name",
-      usage: "xano profile:get-default",
-      examples: ["xano profile:get-default"]
+      name: "profile:get",
+      description: "Print the current default profile name",
+      usage: "xano profile:get",
+      examples: ["xano profile:get"]
     },
     {
       name: "profile:me",
-      description: "Display current authenticated user info",
-      usage: "xano profile:me [-p <profile>]",
-      examples: ["xano profile:me", "xano profile:me -p staging"]
+      description: "Display current authenticated user info (ID, name, email, instance)",
+      usage: "xano profile:me [options]",
+      flags: [
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano profile:me", "xano profile:me -p staging", "xano profile:me -o json"]
     },
     {
       name: "profile:token",
-      description: "Print the access token (for piping to clipboard)",
-      usage: "xano profile:token [-p <profile>]",
+      description: "Print the access token for the default profile (useful for piping)",
+      usage: "xano profile:token",
       examples: [
         "xano profile:token",
         "xano profile:token | pbcopy  # macOS",
         "xano profile:token | xclip   # Linux"
+      ]
+    },
+    {
+      name: "profile:workspace",
+      description: "Print the workspace ID for the default profile",
+      usage: "xano profile:workspace",
+      examples: ["xano profile:workspace"]
+    },
+    {
+      name: "profile:workspace:set",
+      description: "Interactively select and set the workspace for a profile",
+      usage: "xano profile:workspace:set [-p <profile>]",
+      examples: [
+        "xano profile:workspace:set",
+        "xano profile:workspace:set -p staging"
       ]
     }
   ],
@@ -151,7 +186,7 @@ default: production
       steps: [
         "Create production profile: `xano profile:create prod -i <url> -t <token> -b 1`",
         "Create staging profile: `xano profile:create staging -i <url> -t <token> -b 2`",
-        "Set default: `xano profile:set-default prod`",
+        "Set default: `xano profile:set prod`",
         "Use staging when needed: `xano workspace:pull ./code -p staging`"
       ]
     }

--- a/src/cli_docs/topics/release.ts
+++ b/src/cli_docs/topics/release.ts
@@ -1,0 +1,221 @@
+import type { TopicDoc } from "../types.js";
+
+export const releaseDoc: TopicDoc = {
+  topic: "release",
+  title: "Xano CLI - Release Management",
+  description: `Release commands let you manage named releases in a Xano workspace. Releases are versioned snapshots of a branch, used for deploying specific versions to tenants.
+
+## Key Concepts
+
+- **Release**: A named snapshot of a branch at a point in time, used for versioned deployments.
+- **Hotfix release**: A release that bypasses the normal release flow for urgent production fixes.
+- **Export/Import**: Releases can be exported as portable files and imported into other workspaces.
+- **Pull/Push**: Similar to \`workspace:pull\` and \`workspace:push\`, but scoped to a release in multidoc format.
+
+## Release Identification
+
+Releases are identified by their **name** (e.g., "v1.0.0", "2024-03-hotfix").`,
+
+  ai_hints: `**Key concepts:**
+- Releases are versioned snapshots of a branch, created for deployment to tenants
+- Created from branches and deployed to tenants as part of the release lifecycle
+- \`release:pull\` and \`release:push\` work like \`workspace:pull\` and \`workspace:push\` but scoped to releases
+- \`release:export\` and \`release:import\` allow portable release files for moving between workspaces
+- Hotfix releases bypass the normal release flow for urgent production fixes
+- Use \`--table-ids\` on \`release:create\` to include only specific tables in the release
+
+**Typical workflow:**
+1. \`xano release:list\` - see available releases
+2. \`xano release:create -n v1.0.0 -b dev\` - create release from branch
+3. Deploy release to tenant (see tenant topic)
+4. \`xano release:export v1.0.0 --output ./release.tar.gz\` - export for portability`,
+
+  related_topics: ["branch", "tenant", "workspace"],
+
+  commands: [
+    {
+      name: "release:list",
+      description: "List all releases in a workspace",
+      usage: "xano release:list [options]",
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano release:list",
+        "xano release:list -w 123",
+        "xano release:list --output json"
+      ]
+    },
+    {
+      name: "release:get",
+      description: "Get details for a specific release",
+      usage: "xano release:get <release_name> [options]",
+      args: [
+        { name: "release_name", required: true, description: "Name of the release to retrieve" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano release:get v1.0.0",
+        "xano release:get v1.0.0 --output json"
+      ]
+    },
+    {
+      name: "release:create",
+      description: "Create a named release from a branch",
+      usage: "xano release:create --name <name> --branch <branch> [options]",
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Name for the new release" },
+        { name: "branch", short: "b", type: "string", required: true, description: "Branch to create the release from" },
+        { name: "description", short: "d", type: "string", required: false, description: "Description for the release" },
+        { name: "hotfix", type: "boolean", required: false, description: "Mark this release as a hotfix" },
+        { name: "table-ids", type: "string", required: false, description: "Comma-separated table IDs to include in the release" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano release:create -n v1.0.0 -b dev",
+        'xano release:create --name v1.1.0 --branch staging -d "Staging release"',
+        "xano release:create -n hotfix-auth -b v1 --hotfix"
+      ]
+    },
+    {
+      name: "release:edit",
+      description: "Edit release metadata",
+      usage: "xano release:edit <release_name> [options]",
+      args: [
+        { name: "release_name", required: true, description: "Name of the release to edit" }
+      ],
+      flags: [
+        { name: "name", short: "n", type: "string", required: false, description: "New name for the release" },
+        { name: "description", short: "d", type: "string", required: false, description: "New description for the release" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:edit v1.0.0 --name v1.0.1",
+        'xano release:edit v1.0.0 -d "Updated description"'
+      ]
+    },
+    {
+      name: "release:delete",
+      description: "Delete a release",
+      usage: "xano release:delete <release_name> [options]",
+      args: [
+        { name: "release_name", required: true, description: "Name of the release to delete" }
+      ],
+      flags: [
+        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:delete v1.0.0",
+        "xano release:delete v1.0.0 --force"
+      ]
+    },
+    {
+      name: "release:export",
+      description: "Download a release as a portable file",
+      usage: "xano release:export <release_name> [options]",
+      args: [
+        { name: "release_name", required: true, description: "Name of the release to export" }
+      ],
+      flags: [
+        { name: "output", type: "string", required: false, description: "File path for the downloaded release file" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:export v1.0.0",
+        "xano release:export v1.0.0 --output ./releases/v1.0.0.tar.gz"
+      ]
+    },
+    {
+      name: "release:import",
+      description: "Import a release from a file",
+      usage: "xano release:import --file <path> [options]",
+      flags: [
+        { name: "file", type: "string", required: true, description: "Path to the release file to import" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:import --file ./releases/v1.0.0.tar.gz",
+        "xano release:import --file ./release.tar.gz -w 123"
+      ]
+    },
+    {
+      name: "release:pull",
+      description: "Pull release contents to local files in multidoc format",
+      usage: "xano release:pull <directory> --release <name> [options]",
+      args: [
+        { name: "directory", required: true, description: "Local directory to pull release contents into" }
+      ],
+      flags: [
+        { name: "release", short: "r", type: "string", required: true, description: "Name of the release to pull" },
+        { name: "env", type: "boolean", required: false, description: "Include environment variables" },
+        { name: "records", type: "boolean", required: false, description: "Include table records" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:pull ./release-v1 -r v1.0.0",
+        "xano release:pull ./release-v1 --release v1.0.0 --env --records"
+      ]
+    },
+    {
+      name: "release:push",
+      description: "Push local files as a new release",
+      usage: "xano release:push <directory> --name <name> [options]",
+      args: [
+        { name: "directory", required: true, description: "Local directory containing files to push as a release" }
+      ],
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Name for the new release" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch to associate the release with" },
+        { name: "hotfix", type: "boolean", required: false, description: "Mark this release as a hotfix" },
+        { name: "description", short: "d", type: "string", required: false, description: "Description for the release" },
+        { name: "records", type: "boolean", required: false, description: "Include records (--no-records to exclude)" },
+        { name: "env", type: "boolean", required: false, description: "Include environment variables (--no-env to exclude)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" }
+      ],
+      examples: [
+        "xano release:push ./release-v1 -n v1.0.0",
+        "xano release:push ./release-v1 --name v1.1.0 -b dev --records --env",
+        "xano release:push ./release-v1 -n hotfix-1 --hotfix --no-records"
+      ]
+    }
+  ],
+
+  workflows: [
+    {
+      name: "Create and Deploy Release",
+      description: "Create a release from a branch and deploy it to a tenant",
+      steps: [
+        "List branches to find the source: `xano branch:list`",
+        "Create a release: `xano release:create -n v1.0.0 -b dev`",
+        "Verify the release: `xano release:get v1.0.0`",
+        "Deploy to tenant: `xano tenant:deploy_release my-tenant -r v1.0.0`"
+      ],
+      example: `xano branch:list
+xano release:create -n v1.0.0 -b dev -d "Initial release"
+xano release:get v1.0.0
+xano tenant:deploy_release my-tenant -r v1.0.0`
+    },
+    {
+      name: "Export and Import Release",
+      description: "Export a release from one workspace and import it into another",
+      steps: [
+        "Export the release: `xano release:export v1.0.0 --output ./v1.0.0.tar.gz`",
+        "Transfer the file to the target environment",
+        "Import into another workspace: `xano release:import --file ./v1.0.0.tar.gz -w 456`",
+        "Verify: `xano release:list -w 456`"
+      ],
+      example: `# Export from source workspace
+xano release:export v1.0.0 --output ./v1.0.0.tar.gz
+
+# Import into target workspace
+xano release:import --file ./v1.0.0.tar.gz -w 456
+xano release:list -w 456`
+    }
+  ]
+};

--- a/src/cli_docs/topics/run.ts
+++ b/src/cli_docs/topics/run.ts
@@ -28,7 +28,7 @@ This is different from your instance URL used by the Meta API.`,
 - Stored per-project in Run API
 - Override at runtime with \`--env KEY=value\``,
 
-  related_topics: ["profile", "integration"],
+  related_topics: ["function", "profile", "integration"],
 
   commands: [
     {

--- a/src/cli_docs/topics/start.ts
+++ b/src/cli_docs/topics/start.ts
@@ -28,18 +28,17 @@ npm link
 
 ## Quick Setup
 
-Use the interactive wizard to configure your first profile:
+**Option 1: Browser login (recommended)**
+\`\`\`bash
+xano auth
+\`\`\`
+Opens your browser to log in. Automatically creates a profile.
 
+**Option 2: Interactive wizard**
 \`\`\`bash
 xano profile:wizard
 \`\`\`
-
-This will prompt you for:
-1. Your Xano access token (from Settings > Access Tokens in dashboard)
-2. Select your instance
-3. Select a workspace
-4. Select a branch
-5. Select a Run project (optional)
+Prompts you for your access token, instance, workspace, and branch.
 
 ## Credential Storage
 
@@ -71,11 +70,19 @@ All commands support:
 
 | Category | Description |
 |----------|-------------|
+| \`auth\` | Browser-based OAuth login |
 | \`profile:*\` | Manage authentication profiles |
-| \`workspace:*\` | Sync workspaces (pull/push) |
-| \`function:*\` | Manage functions |
+| \`workspace:*\` | Sync workspaces (pull/push), git integration |
+| \`branch:*\` | Manage workspace branches |
+| \`function:*\` | Manage individual functions |
+| \`release:*\` | Create and manage named releases |
+| \`tenant:*\` | Manage tenants, deployments, backups, env vars |
+| \`unit_test:*\` | Run unit tests |
+| \`workflow_test:*\` | Run workflow tests |
 | \`run:*\` | Execute code and manage Run projects |
-| \`static_host:*\` | Deploy static sites |`,
+| \`platform:*\` | View available platform versions |
+| \`static_host:*\` | Deploy static sites |
+| \`update\` | Update CLI to latest version |`,
 
   ai_hints: `**Important:** The CLI is optional - not all users will have it installed. Before suggesting CLI commands, check if the user has it available or ask if they'd like to install it. The Meta API can accomplish the same tasks programmatically.
 
@@ -85,7 +92,7 @@ All commands support:
 - If CLI not installed: Use Meta API endpoints directly
 
 **Getting started workflow (if CLI is installed):**
-1. Run \`xano profile:wizard\` to set up authentication
+1. Run \`xano auth\` (browser login) or \`xano profile:wizard\` (token-based) to set up authentication
 2. Use \`xano workspace:pull ./code\` to download workspace code
 3. Edit .xs files locally
 4. Use \`xano workspace:push ./code\` to deploy changes
@@ -95,7 +102,7 @@ All commands support:
 2. \`XANO_PROFILE\` environment variable
 3. Default profile in credentials.yaml`,
 
-  related_topics: ["profile", "workspace", "integration"],
+  related_topics: ["auth", "profile", "workspace", "integration"],
 
   workflows: [
     {

--- a/src/cli_docs/topics/static_host.ts
+++ b/src/cli_docs/topics/static_host.ts
@@ -15,7 +15,7 @@ export const staticHostDoc: TopicDoc = {
 - Host static documentation sites
 - Serve frontend that calls your Xano APIs`,
 
-  related_topics: ["workspace"],
+  related_topics: ["workspace", "tenant"],
 
   commands: [
     {

--- a/src/cli_docs/topics/tenant.ts
+++ b/src/cli_docs/topics/tenant.ts
@@ -1,0 +1,478 @@
+import type { TopicDoc } from "../types.js";
+
+export const tenantDoc: TopicDoc = {
+  topic: "tenant",
+  title: "Xano CLI - Tenant Management",
+  description: `Tenant commands let you manage tenants in a Xano workspace. Tenants are isolated deployment targets for multi-tenant and white-label applications. Each tenant has its own database, environment variables, and configuration.
+
+## Key Concepts
+
+- **Tenant**: An isolated deployment instance within a workspace, identified by name.
+- **Cluster**: Infrastructure where tenants run (Kubernetes or Xano-managed).
+- **Deployments**: Tenants receive updates via named releases or platform versions.
+- **Environment variables**: Managed per-tenant for configuration isolation.
+- **Backups**: Per-tenant backup and restore for disaster recovery.
+- **Pull/Push**: Similar to \`workspace:pull/push\` but scoped to a specific tenant.
+
+## Tenant Identification
+
+Tenants are identified by their **name** (not numeric IDs).`,
+
+  ai_hints: `**Key concepts:**
+- Tenants are deployment targets for multi-tenant/white-label applications
+- Each tenant is isolated with its own database, env vars, and configuration
+- \`tenant:pull\` and \`tenant:push\` work like \`workspace:pull/push\` but scoped to a tenant
+- Deployments use named releases (\`tenant:deploy_release\`) or platform versions (\`tenant:deploy_platform\`)
+- Environment variables are managed per-tenant for configuration isolation
+- Backups provide disaster recovery per-tenant
+- Clusters manage the infrastructure where tenants run
+
+**Typical workflow:**
+1. Create a tenant: \`xano tenant:create "My Tenant"\`
+2. Set environment variables: \`xano tenant:env:set my-tenant -n API_KEY -v secret\`
+3. Deploy a release: \`xano tenant:deploy_release my-tenant -r v1.0.0\`
+
+**Tenant operations overview:**
+- CRUD: create, get, list, edit, delete
+- Code sync: pull, push
+- Deployment: deploy_release, deploy_platform
+- Configuration: env:get, env:set, env:delete, env:list, env:get_all, env:set_all
+- Backups: backup:create, backup:list, backup:export, backup:import, backup:restore, backup:delete
+- Infrastructure: cluster:create, cluster:list, cluster:get, cluster:edit, cluster:delete
+- License: license:get, license:set
+- Access: impersonate (open tenant in browser)`,
+
+  related_topics: ["workspace", "release", "branch"],
+
+  commands: [
+    // Core CRUD
+    {
+      name: "tenant:list",
+      description: "List all tenants in a workspace",
+      usage: "xano tenant:list [options]",
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano tenant:list", "xano tenant:list -o json"]
+    },
+    {
+      name: "tenant:get",
+      description: "Get details for a specific tenant",
+      usage: "xano tenant:get <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano tenant:get my-tenant", "xano tenant:get my-tenant -o json"]
+    },
+    {
+      name: "tenant:create",
+      description: "Create a new tenant",
+      usage: "xano tenant:create <display_name> [options]",
+      args: [{ name: "display_name", required: true, description: "Display name for the tenant" }],
+      flags: [
+        { name: "description", short: "d", type: "string", required: false, description: "Tenant description" },
+        { name: "cluster_id", type: "string", required: false, description: "Cluster ID to deploy to" },
+        { name: "platform_id", type: "string", required: false, description: "Platform version ID" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        'xano tenant:create "My Tenant"',
+        'xano tenant:create "Production" -d "Production tenant" --cluster_id 1'
+      ]
+    },
+    {
+      name: "tenant:edit",
+      description: "Edit an existing tenant",
+      usage: "xano tenant:edit <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "display", type: "string", required: false, description: "New display name" },
+        { name: "description", short: "d", type: "string", required: false, description: "New description" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ['xano tenant:edit my-tenant --display "New Name"']
+    },
+    {
+      name: "tenant:delete",
+      description: "Delete a tenant",
+      usage: "xano tenant:delete <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:delete old-tenant", "xano tenant:delete old-tenant --force"]
+    },
+    {
+      name: "tenant:impersonate",
+      description: "Open tenant dashboard in browser",
+      usage: "xano tenant:impersonate <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "url-only", type: "boolean", required: false, description: "Print URL without opening browser" },
+        { name: "output", short: "o", type: "string", required: false, description: "Output format: json" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:impersonate my-tenant", "xano tenant:impersonate my-tenant --url-only"]
+    },
+    // Pull/Push
+    {
+      name: "tenant:pull",
+      description: "Pull tenant contents to local files (same multidoc format as workspace:pull)",
+      usage: "xano tenant:pull <directory> --tenant <name> [options]",
+      args: [{ name: "directory", required: true, description: "Local directory to save files" }],
+      flags: [
+        { name: "tenant", short: "t", type: "string", required: true, description: "Tenant name" },
+        { name: "env", type: "boolean", required: false, description: "Include environment variables" },
+        { name: "records", type: "boolean", required: false, description: "Include table records" },
+        { name: "draft", type: "boolean", required: false, description: "Include draft versions" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano tenant:pull ./tenant-code -t my-tenant",
+        "xano tenant:pull ./backup -t my-tenant --env --records"
+      ]
+    },
+    {
+      name: "tenant:push",
+      description: "Push local files to a tenant",
+      usage: "xano tenant:push <directory> --tenant <name> [options]",
+      args: [{ name: "directory", required: true, description: "Local directory containing files" }],
+      flags: [
+        { name: "tenant", short: "t", type: "string", required: true, description: "Tenant name" },
+        { name: "records", type: "boolean", required: false, description: "Include table records" },
+        { name: "env", type: "boolean", required: false, description: "Include environment variables" },
+        { name: "truncate", type: "boolean", required: false, description: "Truncate tables before importing records" },
+        { name: "transaction", type: "boolean", required: false, default: "true", description: "Wrap push in database transaction (--no-transaction to disable)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano tenant:push ./tenant-code -t my-tenant",
+        "xano tenant:push ./data -t my-tenant --records --truncate"
+      ]
+    },
+    // Deployments
+    {
+      name: "tenant:deploy_release",
+      description: "Deploy a named release to a tenant",
+      usage: "xano tenant:deploy_release <tenant_name> --release <name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "release", short: "r", type: "string", required: true, description: "Release name to deploy" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano tenant:deploy_release my-tenant -r v1.0.0",
+        "xano tenant:deploy_release production --release v2.0.0"
+      ]
+    },
+    {
+      name: "tenant:deploy_platform",
+      description: "Deploy a platform version to a tenant",
+      usage: "xano tenant:deploy_platform <tenant_name> --platform_id <id> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "platform_id", type: "string", required: true, description: "Platform version ID to deploy" },
+        { name: "license", type: "string", required: false, description: "Path to license file" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:deploy_platform my-tenant --platform_id 5"]
+    },
+    // Environment Variables
+    {
+      name: "tenant:env:list",
+      description: "List environment variable keys for a tenant",
+      usage: "xano tenant:env:list <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:env:list my-tenant"]
+    },
+    {
+      name: "tenant:env:get",
+      description: "Get a single environment variable",
+      usage: "xano tenant:env:get <tenant_name> --name <key> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Variable name" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:env:get my-tenant -n API_KEY"]
+    },
+    {
+      name: "tenant:env:set",
+      description: "Set an environment variable",
+      usage: "xano tenant:env:set <tenant_name> --name <key> --value <val> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Variable name" },
+        { name: "value", type: "string", required: true, description: "Variable value" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:env:set my-tenant -n API_KEY --value sk-123"]
+    },
+    {
+      name: "tenant:env:delete",
+      description: "Delete an environment variable",
+      usage: "xano tenant:env:delete <tenant_name> --name <key> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Variable name" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:env:delete my-tenant -n OLD_KEY"]
+    },
+    {
+      name: "tenant:env:get_all",
+      description: "Export all environment variables (optionally to YAML file)",
+      usage: "xano tenant:env:get_all <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "file", type: "string", required: false, description: "Output file path (YAML format)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano tenant:env:get_all my-tenant",
+        "xano tenant:env:get_all my-tenant --file ./env.yaml"
+      ]
+    },
+    {
+      name: "tenant:env:set_all",
+      description: "Import all environment variables from YAML (replaces all existing)",
+      usage: "xano tenant:env:set_all <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "file", type: "string", required: false, description: "Input YAML file with env vars" },
+        { name: "clean", type: "boolean", required: false, description: "Remove all existing env vars first" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano tenant:env:set_all my-tenant --file ./env.yaml",
+        "xano tenant:env:set_all my-tenant --file ./env.yaml --clean"
+      ]
+    },
+    // Backups
+    {
+      name: "tenant:backup:list",
+      description: "List backups for a tenant",
+      usage: "xano tenant:backup:list <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano tenant:backup:list my-tenant"]
+    },
+    {
+      name: "tenant:backup:create",
+      description: "Create a backup of a tenant",
+      usage: "xano tenant:backup:create <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:backup:create my-tenant"]
+    },
+    {
+      name: "tenant:backup:export",
+      description: "Download a backup file",
+      usage: "xano tenant:backup:export <tenant_name> --backup_id <id> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "backup_id", type: "string", required: true, description: "Backup ID to export" },
+        { name: "output", type: "string", required: false, description: "File path for the downloaded backup" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:backup:export my-tenant --backup_id 123 --output ./backup.tar.gz"]
+    },
+    {
+      name: "tenant:backup:import",
+      description: "Import a backup file into a tenant",
+      usage: "xano tenant:backup:import <tenant_name> --file <path> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "file", type: "string", required: true, description: "Path to backup file" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:backup:import my-tenant --file ./backup.tar.gz"]
+    },
+    {
+      name: "tenant:backup:restore",
+      description: "Restore a tenant from a backup",
+      usage: "xano tenant:backup:restore <tenant_name> --backup_id <id> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "backup_id", type: "string", required: true, description: "Backup ID to restore from" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:backup:restore my-tenant --backup_id 123"]
+    },
+    {
+      name: "tenant:backup:delete",
+      description: "Delete a backup",
+      usage: "xano tenant:backup:delete <tenant_name> --backup_id <id> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "backup_id", type: "string", required: true, description: "Backup ID to delete" },
+        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:backup:delete my-tenant --backup_id 123 --force"]
+    },
+    // License
+    {
+      name: "tenant:license:get",
+      description: "Get tenant license tier",
+      usage: "xano tenant:license:get <tenant_name> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:license:get my-tenant"]
+    },
+    {
+      name: "tenant:license:set",
+      description: "Set tenant license tier",
+      usage: "xano tenant:license:set <tenant_name> --license <tier> [options]",
+      args: [{ name: "tenant_name", required: true, description: "Tenant name" }],
+      flags: [
+        { name: "license", type: "string", required: true, description: "License tier to set" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:license:set my-tenant --license tier2"]
+    },
+    // Clusters
+    {
+      name: "tenant:cluster:list",
+      description: "List all clusters",
+      usage: "xano tenant:cluster:list [options]",
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano tenant:cluster:list", "xano tenant:cluster:list -o json"]
+    },
+    {
+      name: "tenant:cluster:get",
+      description: "Get cluster details",
+      usage: "xano tenant:cluster:get <cluster_id> [options]",
+      args: [{ name: "cluster_id", required: true, description: "Cluster ID" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: ["xano tenant:cluster:get 1"]
+    },
+    {
+      name: "tenant:cluster:create",
+      description: "Create a new cluster",
+      usage: "xano tenant:cluster:create --name <name> [options]",
+      flags: [
+        { name: "name", short: "n", type: "string", required: true, description: "Cluster name" },
+        { name: "type", type: "string", required: false, description: "Cluster type: run or k8s" },
+        { name: "description", short: "d", type: "string", required: false, description: "Cluster description" },
+        { name: "credentials_file", type: "string", required: false, description: "Path to kubeconfig.yaml (for k8s type)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        'xano tenant:cluster:create -n "Production Cluster"',
+        'xano tenant:cluster:create -n "K8s Cluster" --type k8s --credentials_file ./kubeconfig.yaml'
+      ]
+    },
+    {
+      name: "tenant:cluster:edit",
+      description: "Edit a cluster",
+      usage: "xano tenant:cluster:edit <cluster_id> [options]",
+      args: [{ name: "cluster_id", required: true, description: "Cluster ID" }],
+      flags: [
+        { name: "name", short: "n", type: "string", required: false, description: "New cluster name" },
+        { name: "description", short: "d", type: "string", required: false, description: "New description" },
+        { name: "domain", type: "string", required: false, description: "New domain" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ['xano tenant:cluster:edit 1 -n "Updated Cluster"']
+    },
+    {
+      name: "tenant:cluster:delete",
+      description: "Delete a cluster",
+      usage: "xano tenant:cluster:delete <cluster_id> [options]",
+      args: [{ name: "cluster_id", required: true, description: "Cluster ID" }],
+      flags: [
+        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:cluster:delete 1 --force"]
+    },
+    {
+      name: "tenant:cluster:license:get",
+      description: "Get cluster kubeconfig",
+      usage: "xano tenant:cluster:license:get <cluster_id> [options]",
+      args: [{ name: "cluster_id", required: true, description: "Cluster ID" }],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:cluster:license:get 1"]
+    },
+    {
+      name: "tenant:cluster:license:set",
+      description: "Set cluster kubeconfig",
+      usage: "xano tenant:cluster:license:set <cluster_id> [options]",
+      args: [{ name: "cluster_id", required: true, description: "Cluster ID" }],
+      flags: [
+        { name: "file", type: "string", required: false, description: "Path to kubeconfig.yaml" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: ["xano tenant:cluster:license:set 1 --file ./kubeconfig.yaml"]
+    }
+  ],
+
+  workflows: [
+    {
+      name: "Deploy Release to Tenant",
+      description: "Create a release and deploy it to a tenant",
+      steps: [
+        "Create a release from a branch: `xano release:create -n v1.0.0 -b dev`",
+        "Deploy to tenant: `xano tenant:deploy_release my-tenant -r v1.0.0`",
+        "Verify tenant: `xano tenant:get my-tenant`"
+      ],
+      example: `xano release:create -n v1.0.0 -b dev
+xano tenant:deploy_release my-tenant -r v1.0.0
+xano tenant:get my-tenant`
+    },
+    {
+      name: "Tenant Environment Setup",
+      description: "Create a tenant and configure its environment",
+      steps: [
+        'Create tenant: `xano tenant:create "My Tenant"`',
+        "Set environment variables: `xano tenant:env:set my-tenant -n DB_HOST --value db.example.com`",
+        "Set more vars: `xano tenant:env:set my-tenant -n API_KEY --value sk-123`",
+        "Deploy a release: `xano tenant:deploy_release my-tenant -r v1.0.0`",
+        "Verify env: `xano tenant:env:list my-tenant`"
+      ],
+      example: `xano tenant:create "My Tenant"
+xano tenant:env:set my-tenant -n DB_HOST --value db.example.com
+xano tenant:env:set my-tenant -n API_KEY --value sk-123
+xano tenant:deploy_release my-tenant -r v1.0.0`
+    },
+    {
+      name: "Backup and Restore",
+      description: "Create, export, and restore tenant backups",
+      steps: [
+        "Create a backup: `xano tenant:backup:create my-tenant`",
+        "List backups: `xano tenant:backup:list my-tenant`",
+        "Export backup: `xano tenant:backup:export my-tenant --backup_id 123 --output ./backup.tar.gz`",
+        "Restore if needed: `xano tenant:backup:restore my-tenant --backup_id 123`"
+      ],
+      example: `xano tenant:backup:create my-tenant
+xano tenant:backup:list my-tenant
+xano tenant:backup:export my-tenant --backup_id 123 --output ./backup.tar.gz
+
+# To restore:
+xano tenant:backup:restore my-tenant --backup_id 123`
+    }
+  ]
+};

--- a/src/cli_docs/topics/unit_test.ts
+++ b/src/cli_docs/topics/unit_test.ts
@@ -1,0 +1,94 @@
+import type { TopicDoc } from "../types.js";
+
+export const unitTestDoc: TopicDoc = {
+  topic: "unit_test",
+  title: "Xano CLI - Unit Test Management",
+  description: `Unit test commands let you run automated tests on individual Xano functions and endpoints. Tests validate that your functions produce expected outputs for given inputs.
+
+## Key Concepts
+
+- **Unit tests** are created and configured in the Xano dashboard, not via the CLI.
+- The CLI is used to **list and run** tests, making it ideal for CI/CD pipelines.
+- Test output shows PASS/FAIL status with error details for failed tests.
+- Use \`--obj-type\` to filter tests by object type (e.g., function, API endpoint).
+- Use \`--branch\` to run tests against a specific branch.`,
+
+  ai_hints: `**Key concepts:**
+- Unit tests are created in the Xano dashboard; the CLI is for running them
+- Use \`unit_test:run_all\` in CI/CD pipelines for automated testing
+- Output shows PASS/FAIL with error details for each test
+- \`--obj-type\` filters tests by object type (e.g., function, API endpoint)
+- \`--branch\` specifies which branch to test against
+
+**CI/CD integration:**
+- Use \`unit_test:run_all -o json\` for machine-readable output
+- Combine with \`workflow_test:run_all\` for full test coverage
+- Filter by branch with \`--branch\` to test specific branches`,
+
+  related_topics: ["workflow_test", "workspace", "function"],
+
+  commands: [
+    {
+      name: "unit_test:list",
+      description: "List unit tests in the workspace",
+      usage: "xano unit_test:list [options]",
+      flags: [
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch to list tests from" },
+        { name: "obj-type", type: "string", required: false, description: "Filter by object type" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano unit_test:list",
+        "xano unit_test:list --branch dev",
+        "xano unit_test:list --obj-type function -o json"
+      ]
+    },
+    {
+      name: "unit_test:run",
+      description: "Run a single unit test by ID",
+      usage: "xano unit_test:run <unit_test_id> [options]",
+      args: [
+        { name: "unit_test_id", required: true, description: "ID of the unit test to run" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano unit_test:run 123",
+        "xano unit_test:run 123 -o json"
+      ]
+    },
+    {
+      name: "unit_test:run_all",
+      description: "Run all unit tests in the workspace",
+      usage: "xano unit_test:run_all [options]",
+      flags: [
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch to run tests against" },
+        { name: "obj-type", type: "string", required: false, description: "Filter by object type" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano unit_test:run_all",
+        "xano unit_test:run_all --branch dev -o json",
+        "xano unit_test:run_all --obj-type function"
+      ]
+    }
+  ],
+
+  workflows: [
+    {
+      name: "Run Tests in CI/CD",
+      description: "Run all unit tests as part of a CI/CD pipeline",
+      steps: [
+        "List available tests: `xano unit_test:list`",
+        "Run all tests: `xano unit_test:run_all`",
+        "Check output for PASS/FAIL results"
+      ],
+      example: `xano unit_test:list
+xano unit_test:run_all -o json`
+    }
+  ]
+};

--- a/src/cli_docs/topics/update.ts
+++ b/src/cli_docs/topics/update.ts
@@ -1,0 +1,34 @@
+import type { TopicDoc } from "../types.js";
+
+export const updateDoc: TopicDoc = {
+  topic: "update",
+  title: "Xano CLI - Update",
+  description: `The update command lets you check for and install CLI updates.`,
+
+  ai_hints: `**When to suggest updating:**
+- User encounters unexpected behavior that might be fixed in a newer version
+- User asks about new features
+- Before troubleshooting CLI issues
+
+**Update uses npm** - runs \`npm install -g @xano/cli\` under the hood.
+**Beta channel** - use \`--beta\` to get pre-release versions for testing new features.`,
+
+  related_topics: ["start"],
+
+  commands: [
+    {
+      name: "update",
+      description: "Update the Xano CLI to the latest version",
+      usage: "xano update [options]",
+      flags: [
+        { name: "check", type: "boolean", required: false, description: "Check for updates without installing" },
+        { name: "beta", type: "boolean", required: false, description: "Update to the latest beta version" }
+      ],
+      examples: [
+        "xano update",
+        "xano update --check",
+        "xano update --beta"
+      ]
+    }
+  ]
+};

--- a/src/cli_docs/topics/workflow_test.ts
+++ b/src/cli_docs/topics/workflow_test.ts
@@ -1,0 +1,125 @@
+import type { TopicDoc } from "../types.js";
+
+export const workflowTestDoc: TopicDoc = {
+  topic: "workflow_test",
+  title: "Xano CLI - Workflow Test Management",
+  description: `Workflow test commands let you run end-to-end tests that exercise multi-step workflows. Unlike unit tests which test individual functions, workflow tests validate complete request flows.
+
+## Key Concepts
+
+- **Workflow tests** are more comprehensive than unit tests, testing full request flows.
+- Tests are created and configured in the Xano dashboard; the CLI is for listing, viewing, and running them.
+- The \`get\` command supports \`xs\` output format for viewing test XanoScript.
+- Use \`run_all\` in CI/CD pipelines for automated end-to-end validation.`,
+
+  ai_hints: `**Key concepts:**
+- Workflow tests are more comprehensive than unit tests, testing full request flows
+- Tests are created in the Xano dashboard; the CLI is for running them
+- \`workflow_test:get\` supports \`xs\` output format for viewing test XanoScript
+- Use \`workflow_test:run_all\` in CI/CD pipelines for automated testing
+
+**CI/CD integration:**
+- Use \`workflow_test:run_all -o json\` for machine-readable output
+- Combine with \`unit_test:run_all\` for full test coverage
+- Filter by branch with \`--branch\` to test specific branches
+
+**Viewing test details:**
+- Use \`workflow_test:get <id> -o xs\` to view the test XanoScript
+- Use \`--include-draft\` to view draft versions of tests`,
+
+  related_topics: ["unit_test", "workspace", "branch"],
+
+  commands: [
+    {
+      name: "workflow_test:list",
+      description: "List workflow tests in the workspace",
+      usage: "xano workflow_test:list [options]",
+      flags: [
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch to list tests from" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano workflow_test:list",
+        "xano workflow_test:list --branch dev",
+        "xano workflow_test:list -o json"
+      ]
+    },
+    {
+      name: "workflow_test:get",
+      description: "Get details for a specific workflow test",
+      usage: "xano workflow_test:get <workflow_test_id> [options]",
+      args: [
+        { name: "workflow_test_id", required: true, description: "ID of the workflow test to retrieve" }
+      ],
+      flags: [
+        { name: "include-draft", type: "boolean", required: false, description: "Include draft version if available" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: xs or json" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano workflow_test:get 456",
+        "xano workflow_test:get 456 -o xs",
+        "xano workflow_test:get 456 --include-draft -o json"
+      ]
+    },
+    {
+      name: "workflow_test:run",
+      description: "Run a single workflow test by ID",
+      usage: "xano workflow_test:run <workflow_test_id> [options]",
+      args: [
+        { name: "workflow_test_id", required: true, description: "ID of the workflow test to run" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano workflow_test:run 456",
+        "xano workflow_test:run 456 -o json"
+      ]
+    },
+    {
+      name: "workflow_test:run_all",
+      description: "Run all workflow tests in the workspace",
+      usage: "xano workflow_test:run_all [options]",
+      flags: [
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch to run tests against" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano workflow_test:run_all",
+        "xano workflow_test:run_all --branch dev -o json"
+      ]
+    },
+    {
+      name: "workflow_test:delete",
+      description: "Delete a workflow test by ID",
+      usage: "xano workflow_test:delete <workflow_test_id> [options]",
+      args: [
+        { name: "workflow_test_id", required: true, description: "ID of the workflow test to delete" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID" }
+      ],
+      examples: [
+        "xano workflow_test:delete 456"
+      ]
+    }
+  ],
+
+  workflows: [
+    {
+      name: "Validate Workflows Before Deploy",
+      description: "Run all workflow tests to validate before deployment",
+      steps: [
+        "List available tests: `xano workflow_test:list`",
+        "Run all tests: `xano workflow_test:run_all`",
+        "Check results for PASS/FAIL status"
+      ],
+      example: `xano workflow_test:list
+xano workflow_test:run_all -o json`
+    }
+  ]
+};

--- a/src/cli_docs/topics/workspace.ts
+++ b/src/cli_docs/topics/workspace.ts
@@ -81,9 +81,21 @@ After \`workspace:pull\`, files are organized using snake_case naming:
 
 **Branch handling:**
 - Use \`-b\` flag or set branch in profile
-- Pull from one branch, push to another is supported`,
+- Pull from one branch, push to another is supported
 
-  related_topics: ["start", "function", "integration"],
+**Push modes:**
+- Default (partial): Only pushes changed files
+- \`--sync\`: Full push of all files
+- \`--sync --delete\`: Full push AND removes remote objects not in local
+- \`--dry-run\`: Preview what would change without applying
+- \`--include/-i\` and \`--exclude/-e\`: Glob patterns for selective push
+
+**Git integration:**
+- \`workspace:git:pull\` pulls XanoScript directly from GitHub/GitLab repos
+- Supports private repos with \`--token\` flag
+- Can pull from a specific subdirectory with \`--path\``,
+
+  related_topics: ["start", "branch", "function", "release", "integration"],
 
   commands: [
     {
@@ -167,37 +179,72 @@ After \`workspace:pull\`, files are organized using snake_case naming:
     },
     {
       name: "workspace:pull",
-      description: "Download workspace code to local directory",
+      description: "Download workspace code to local directory. Splits multidoc into individual .xs files organized by type.",
       usage: "xano workspace:pull <directory> [options]",
       args: [
         { name: "directory", required: true, description: "Local directory to save files" }
       ],
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile default if not set)" },
-        { name: "branch", short: "b", type: "string", required: false, description: "Branch ID to pull from" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch label to pull from" },
         { name: "env", type: "boolean", required: false, description: "Include environment variables" },
+        { name: "draft", type: "boolean", required: false, description: "Include draft versions of functions" },
         { name: "records", type: "boolean", required: false, description: "Include table records" }
       ],
       examples: [
         "xano workspace:pull ./my-app",
-        "xano workspace:pull ./staging-code -b 2",
-        "xano workspace:pull ./backup --env --records"
+        "xano workspace:pull ./staging-code -b dev",
+        "xano workspace:pull ./backup --env --records --draft"
       ]
     },
     {
       name: "workspace:push",
-      description: "Upload local XanoScript files to workspace",
+      description: "Upload local XanoScript files to workspace. By default only pushes changed files (partial push). Use --sync for a full push.",
       usage: "xano workspace:push <directory> [options]",
       args: [
         { name: "directory", required: true, description: "Local directory containing .xs files" }
       ],
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile default if not set)" },
-        { name: "branch", short: "b", type: "string", required: false, description: "Branch ID to push to" }
+        { name: "branch", short: "b", type: "string", required: false, description: "Branch label to push to" },
+        { name: "sync", type: "boolean", required: false, description: "Full push (default is partial/changed-only)" },
+        { name: "delete", type: "boolean", required: false, description: "Delete remote objects not in local files (requires --sync)" },
+        { name: "dry-run", type: "boolean", required: false, description: "Preview changes without applying" },
+        { name: "force", type: "boolean", required: false, description: "Skip confirmation prompt" },
+        { name: "env", type: "boolean", required: false, description: "Include environment variables" },
+        { name: "records", type: "boolean", required: false, description: "Include table records" },
+        { name: "truncate", type: "boolean", required: false, description: "Truncate tables before importing records" },
+        { name: "transaction", type: "boolean", required: false, default: "true", description: "Wrap push in database transaction (--no-transaction to disable)" },
+        { name: "guids", type: "boolean", required: false, default: "true", description: "Write GUIDs back to local files after push (--no-guids to disable)" },
+        { name: "include", short: "i", type: "string", required: false, description: "Glob pattern to include specific files (repeatable)" },
+        { name: "exclude", short: "e", type: "string", required: false, description: "Glob pattern to exclude specific files (repeatable)" }
       ],
       examples: [
         "xano workspace:push ./my-app",
-        "xano workspace:push ./my-app -b 2"
+        "xano workspace:push ./my-app -b dev",
+        "xano workspace:push ./my-app --dry-run",
+        "xano workspace:push ./my-app --sync --delete --force",
+        "xano workspace:push ./my-app -i 'api/**' -i 'function/**'",
+        "xano workspace:push ./my-app -e 'table/**' --records --truncate"
+      ]
+    },
+    {
+      name: "workspace:git:pull",
+      description: "Pull XanoScript files directly from a git repository (GitHub, GitLab, etc.)",
+      usage: "xano workspace:git:pull <directory> --repo <url> [options]",
+      args: [
+        { name: "directory", required: true, description: "Local directory to save files" }
+      ],
+      flags: [
+        { name: "repo", short: "r", type: "string", required: true, description: "Git repository URL (HTTPS or SSH)" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Git branch, tag, or ref to pull from" },
+        { name: "path", type: "string", required: false, description: "Subdirectory within the repo to pull from" },
+        { name: "token", short: "t", type: "string", required: false, description: "Personal access token for private repos" }
+      ],
+      examples: [
+        "xano workspace:git:pull ./code -r https://github.com/org/repo.git",
+        "xano workspace:git:pull ./code -r https://github.com/org/repo.git -b main --path src/xano",
+        "xano workspace:git:pull ./code -r https://github.com/org/private-repo.git -t ghp_token123"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Add 7 new CLI documentation topics: `auth`, `release`, `tenant`, `unit_test`, `workflow_test`, `platform`, `update`
- Update 8 existing topics with new flags, commands, and cross-references (profile command renames, workspace push modes, git integration, etc.)
- Update README Available Topics table to include all new CLI doc topics
- Bump version to 1.0.61

## Test plan
- [ ] Verify `npm run build` succeeds
- [ ] Verify `npm test` passes
- [ ] Spot-check new topics via `cli_docs({ topic: "auth" })`, `cli_docs({ topic: "tenant" })`, etc.
- [ ] Confirm README topic table matches registered topics in `src/cli_docs/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)