### PR TITLE
Bump @xano/xanoscript-language-server to 11.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.61",
+      "version": "1.0.62",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@xano/xanoscript-language-server": "^11.11.0",
+        "@xano/xanoscript-language-server": "^11.12.0",
         "minimatch": "^10.1.2"
       },
       "bin": {
@@ -1092,9 +1092,9 @@
       }
     },
     "node_modules/@xano/xanoscript-language-server": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-11.11.0.tgz",
-      "integrity": "sha512-JBRrdCNwa/WzZ5fXlcSZNOQbGXSQFXmSD6AWX0jvHj9nfSTY3b2lVObqNEj4Tpe8taMy90LxLIATl1UdcowruQ==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-11.12.0.tgz",
+      "integrity": "sha512-bqqBr9IWmEYaixIsPGOlifwL8SmUmXW5T3lVTMDV7MgtSfwYAA7KSPRE8w53jBVopkZqSKkHgTf92CmFDaoaZg==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",
@@ -59,7 +59,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@xano/xanoscript-language-server": "^11.11.0",
+    "@xano/xanoscript-language-server": "^11.12.0",
     "minimatch": "^10.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps `@xano/xanoscript-language-server` from 11.11.0 to 11.12.0
- Bumps package version from 1.0.62 to 1.0.63

## Test plan
- [ ] Verify XanoScript validation works with the updated language server
- [ ] Confirm no regressions in MCP server functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)