### PR TITLE
Add schema ordering best practice to tables docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/tables.md
+++ b/src/xanoscript_docs/tables.md
@@ -17,8 +17,8 @@ table "<name>" {
   auth = false                    // true if used for authentication
   schema {
     int id                        // Primary key (required)
-    text name filters=trim
     timestamp created_at?=now
+    text name filters=trim
   }
   index = [
     {type: "primary", field: [{name: "id"}]}
@@ -45,12 +45,12 @@ table "user" {
   auth = true
   schema {
     int id
+    timestamp created_at?=now
     text name filters=trim
     email email filters=trim|lower {
       sensitive = true
     }
     password password
-    timestamp created_at?=now
   }
   index = [
     {type: "primary", field: [{name: "id"}]}
@@ -68,10 +68,10 @@ table "user" {
 ```xs
 schema {
   int id
+  timestamp created_at
   text name
   decimal price
   bool is_active
-  timestamp created_at
   date birth_date
 }
 ```
@@ -322,6 +322,7 @@ table "order" {
 1. **Always define `int id`** - Every table requires a primary key field named `id`
 2. **Use `auth = true`** only for the authentication table (typically just `user`)
 3. **Add indexes** for fields used in `db.query` WHERE clauses and JOINs to avoid full table scans
+4. **Add new fields to the bottom of the schema** - When adding new fields to an existing table, append them to the end of the schema block rather than inserting them in the middle. This preserves column ordering consistency and avoids unexpected side effects
 
 ---
 


### PR DESCRIPTION
## Summary
- Added best practice recommending new schema fields be appended to the bottom of the schema block
- Reordered fields in doc examples to follow this convention (e.g., `created_at` moved up near `id`)
- Bumped version to 1.0.65

## Test plan
- [ ] Verify tables.md renders correctly
- [ ] Confirm examples follow the new ordering convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)