### PR TITLE
Expand comments section with placement examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -135,10 +135,24 @@ XanoScript uses specific type names:
 
 ### Comments
 
+XanoScript supports `//` single-line comments. They can be placed above an object definition, above inputs, and above stack items:
+
 ```xs
-// Single-line comment
-var $total {
-  value = 0
+// Example
+function empty {
+  input {
+    // Example
+    text test
+  }
+
+  stack {
+    // Example
+    var $x1 {
+      value = ""
+    }
+  }
+
+  response = $x1
 }
 ```
 


### PR DESCRIPTION
## Summary
- Document that `//` comments can be placed above object definitions, inputs, and stack items
- Bump version to 1.0.66

## Test plan
- [ ] Review rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)