### PR TITLE
Add severity support to validation diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.62",
+  "version": "1.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "1.0.62",
+      "version": "1.0.69",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@xano/xanoscript-language-server": "^11.12.0",
+        "@xano/xanoscript-language-server": "^12.0.0",
         "minimatch": "^10.1.2"
       },
       "bin": {
@@ -1092,9 +1092,9 @@
       }
     },
     "node_modules/@xano/xanoscript-language-server": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-11.12.0.tgz",
-      "integrity": "sha512-bqqBr9IWmEYaixIsPGOlifwL8SmUmXW5T3lVTMDV7MgtSfwYAA7KSPRE8w53jBVopkZqSKkHgTf92CmFDaoaZg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-12.0.0.tgz",
+      "integrity": "sha512-8K+bja5xvBNWQSFtgbLmUUbdYNqzkQn+l8ceyCI+OtqU0+rIUZtaJm0UbTlJdVcyvZ2lIJ7y1cClur9BimtfrA==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@xano/xanoscript-language-server": "^11.12.0",
+    "@xano/xanoscript-language-server": "^12.0.0",
     "minimatch": "^10.1.2"
   },
   "devDependencies": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -52,6 +52,8 @@ export {
   type ValidateXanoscriptArgs,
   type ValidationResult,
   type ParserDiagnostic,
+  type DiagnosticSeverity,
+  SEVERITY,
 } from "./tools/validate_xanoscript.js";
 
 // XanoScript Documentation

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -35,7 +35,15 @@ export interface ValidateXanoscriptArgs {
   pattern?: string;
 }
 
+export const SEVERITY = {
+  ERROR: 1,
+  WARNING: 2,
+} as const;
+
+export type DiagnosticSeverity = (typeof SEVERITY)[keyof typeof SEVERITY];
+
 export interface ParserDiagnostic {
+  severity: DiagnosticSeverity;
   range: {
     start: { line: number; character: number };
     end: { line: number; character: number };
@@ -258,7 +266,48 @@ function validateCode(
     const scheme = getSchemeFromContent(text);
     const parser = xanoscriptParser(text, scheme);
 
-    if (parser.errors.length === 0) {
+    function toDiagnostic(
+      item: {
+        token?: { startOffset: number; endOffset: number };
+        message: string;
+        name?: string;
+      },
+      severity: DiagnosticSeverity
+    ): ParserDiagnostic {
+      const startOffset = item.token?.startOffset ?? 0;
+      const endOffset = item.token?.endOffset ?? 5;
+
+      const lines = text.substring(0, startOffset).split("\n");
+      const line = lines.length - 1;
+      const character = lines[lines.length - 1].length;
+
+      const endLines = text.substring(0, endOffset + 1).split("\n");
+      const endLine = endLines.length - 1;
+      const endCharacter = endLines[endLines.length - 1].length;
+
+      const enhancedMessage = enhanceErrorMessage(item.message, text, line);
+
+      return {
+        severity,
+        range: {
+          start: { line, character },
+          end: { line: endLine, character: endCharacter },
+        },
+        message: enhancedMessage,
+        source: item.name || "XanoScript Parser",
+      };
+    }
+
+    const diagnostics: ParserDiagnostic[] = [
+      ...parser.errors.map((e: { token?: { startOffset: number; endOffset: number }; message: string; name?: string }) =>
+        toDiagnostic(e, SEVERITY.ERROR)
+      ),
+      ...((parser.warnings as Array<{ token?: { startOffset: number; endOffset: number }; message: string; name?: string }>) ?? []).map((w) =>
+        toDiagnostic(w, SEVERITY.WARNING)
+      ),
+    ];
+
+    if (diagnostics.length === 0) {
       return {
         valid: true,
         errors: [],
@@ -269,47 +318,32 @@ function validateCode(
       };
     }
 
-    const diagnostics: ParserDiagnostic[] = parser.errors.map(
-      (error: {
-        token?: { startOffset: number; endOffset: number };
-        message: string;
-        name?: string;
-      }) => {
-        const startOffset = error.token?.startOffset ?? 0;
-        const endOffset = error.token?.endOffset ?? 5;
+    const errors = diagnostics.filter((d) => d.severity === SEVERITY.ERROR);
+    const warnings = diagnostics.filter((d) => d.severity === SEVERITY.WARNING);
+    const hasErrors = errors.length > 0;
 
-        const lines = text.substring(0, startOffset).split("\n");
-        const line = lines.length - 1;
-        const character = lines[lines.length - 1].length;
-
-        const endLines = text.substring(0, endOffset + 1).split("\n");
-        const endLine = endLines.length - 1;
-        const endCharacter = endLines[endLines.length - 1].length;
-
-        // Enhance error message with suggestions
-        const enhancedMessage = enhanceErrorMessage(error.message, text, line);
-
-        return {
-          range: {
-            start: { line, character },
-            end: { line: endLine, character: endCharacter },
-          },
-          message: enhancedMessage,
-          source: error.name || "XanoScript Parser",
-        };
-      }
-    );
-
-    const errorMessages = diagnostics.map((d: ParserDiagnostic, i: number) => {
+    const formatDiagnostic = (d: ParserDiagnostic, i: number) => {
+      const label = d.severity === SEVERITY.ERROR ? "ERROR" : "WARNING";
       const location = `Line ${d.range.start.line + 1}, Column ${d.range.start.character + 1}`;
-      return `${i + 1}. [${location}] ${d.message}`;
-    });
+      return `${i + 1}. [${label}] [${location}] ${d.message}`;
+    };
 
-    const prefix = filePath ? `✗ ${basename(filePath)}: ` : "";
+    const messageLines: string[] = [];
+    const prefix = filePath ? `${hasErrors ? "✗" : "⚠"} ${basename(filePath)}: ` : "";
+
+    if (errors.length > 0) {
+      messageLines.push(`${prefix}Found ${errors.length} error(s)${warnings.length > 0 ? ` and ${warnings.length} warning(s)` : ""}:`);
+    } else {
+      messageLines.push(`${prefix}Found ${warnings.length} warning(s):`);
+    }
+
+    messageLines.push("");
+    messageLines.push(...diagnostics.map(formatDiagnostic));
+
     return {
-      valid: false,
+      valid: !hasErrors,
       errors: diagnostics,
-      message: `${prefix}Found ${diagnostics.length} error(s):\n\n${errorMessages.join("\n")}`,
+      message: messageLines.join("\n"),
       file_path: filePath,
     };
   } catch (error: unknown) {

--- a/src/xanoscript.test.ts
+++ b/src/xanoscript.test.ts
@@ -47,12 +47,10 @@ describe("xanoscript module", () => {
         "integrations/external-apis",
         "integrations/utilities",
         "frontend",
-        "run",
         "addons",
         "debugging",
         "performance",
         "realtime",
-        "schema",
         "security",
         "streaming",
         "middleware",
@@ -178,7 +176,6 @@ describe("xanoscript module", () => {
     it("should match run files", () => {
       const result = getDocsForFilePath("run/job/main.xs");
       expect(result).toContain("syntax");
-      expect(result).toContain("run");
     });
 
     it("should not include readme automatically", () => {


### PR DESCRIPTION
## Summary
- Upgrade `@xano/xanoscript-language-server` from v11 to v12 which now includes `severity` on diagnostics
- Process both `parser.errors` (severity ERROR) and `parser.warnings` (severity WARNING) in the validator
- Warnings no longer mark code as invalid — only errors do
- Export `SEVERITY` constant and `DiagnosticSeverity` type from `lib.ts`
- Fix tests for removed `run`/`schema` doc topics

## Test plan
- [x] All 184 tests pass
- [x] TypeScript type check passes
- [ ] Verify validation output correctly labels errors vs warnings
- [ ] Verify code with only warnings returns `valid: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)