### PR TITLE
Document xano-init skill install in README

### DIFF
--- a/.claude/skills/xano-init/SKILL.md
+++ b/.claude/skills/xano-init/SKILL.md
@@ -1,0 +1,431 @@
+---
+name: xano-init
+description: Discover and profile a Xano workspace to understand how to develop safely with it using the sandbox workflow
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__xano-developer__meta_api_docs, mcp__xano-developer__cli_docs, mcp__xano-developer__xanoscript_docs, mcp__xano-developer__validate_xanoscript, mcp__xano-developer__mcp_version, WebFetch, ToolSearch, AskUserQuestion]
+---
+
+# Xano Workspace Init
+
+You are running an interactive setup process to understand how to safely and effectively develop against a Xano workspace. Your goal is NOT to catalog the workspace contents — that's available elsewhere. Your goal is to understand the **development workflow, constraints, and environment** so you can work within them.
+
+**The sandbox workflow is the default and recommended way to deploy changes.** Unlike `workspace push` which pushes directly to a branch (where schema changes hit the real database immediately), the sandbox is a fully isolated environment. Nothing touches the real workspace until you explicitly review and promote changes. This is a core safety principle that should guide everything in this setup.
+
+This is a guided, conversational process. Ask questions, validate answers, and build up a development playbook.
+
+---
+
+## Phase 1: Environment Check (automated)
+
+Run these checks silently before asking the user anything. Gather all results in parallel, then present a status summary.
+
+### Package reference (for version comparisons)
+- **Xano CLI** npm package: `@xano/cli` — install: `npm install -g @xano/cli`
+- **Xano Developer MCP** npm package: `@xano/developer-mcp` — install: `claude mcp add xano -- npx -y @xano/developer-mcp`
+
+### 1a. MCP Availability & Version
+- Use `ToolSearch` to check if `mcp__xano-developer__mcp_version` is available
+- If available, call it to get the installed version
+- Run `npm view @xano/developer-mcp version` to get the latest published version
+- Compare: if installed < latest, flag as outdated
+
+### 1b. CLI Installation & Version
+- Run `xano --version` (global install) to check if the CLI is installed and get the version
+- Run `npm view @xano/cli version` to get the latest published version
+- Compare: if installed < latest, flag as outdated
+- If `xano` is not found globally, try `npx xano --version` as fallback (but note this doesn't mean it's properly installed)
+- Run `xano sandbox --help` to verify sandbox commands are available. If the command is not recognized, the CLI is too old and must be updated.
+
+### 1c. Auth State
+- Run `xano profile token` (suppress output, only check exit code) to detect if there's an active session
+- Run `xano profile me` to get the user name, email, and instance URL
+- Do NOT display the token to the user
+
+### 1d. Local Project State
+- Check if there's already a `xano/` folder in the project
+- Check if `.claude/xano-workspace-profile.md` already exists (previous init)
+- Check if `CLAUDE.md` already references Xano configuration
+- Check for any `.xs` files in the project
+
+### 1e. Present Environment Status
+
+Show the user a clear status table with version details:
+
+```
+## Environment Status
+
+| Check              | Status |
+|--------------------|--------|
+| Xano MCP tools     | ✅ Up to date (v1.0.61) / ⚠️ Outdated (v1.0.58 → v1.0.61 available) / ❌ Not installed |
+| Xano CLI           | ✅ Up to date (v0.0.94) / ⚠️ Outdated (v0.0.90 → v0.0.94 available) / ❌ Not installed |
+| Sandbox support    | ✅ Available / ❌ Not available (CLI update required) |
+| Auth session       | ✅ [User Name] (instance.xano.io) / ❌ Not authenticated |
+| Local xano/ folder | ✅ Found (X .xs files) / ⚠️ Not found |
+| Previous init      | ✅ Profile exists / ➖ Fresh setup |
+```
+
+### 1f. Fix missing or outdated tools BEFORE continuing
+
+If any critical tool is missing or outdated, stop and provide the exact fix. Do not proceed to Phase 2 until the user confirms they've resolved it.
+
+**MCP not installed:**
+```bash
+claude mcp add xano -- npx -y @xano/developer-mcp
+# Restart Claude Code after running this for MCP tools to load
+```
+
+**MCP outdated** (only applies if installed globally, not via npx which auto-fetches latest):
+```bash
+npm update -g @xano/developer-mcp
+```
+
+**CLI not installed:**
+```bash
+npm install -g @xano/cli
+```
+
+**CLI outdated or sandbox commands not available:**
+```bash
+xano update
+# or: npm install -g @xano/cli
+```
+The sandbox workflow (`xano sandbox *`) is the recommended safe deployment method. If sandbox commands are not recognized after updating, the user's CLI may need a fresh install: `npm install -g @xano/cli`.
+
+**Not authenticated:**
+```bash
+xano auth   # opens browser for OAuth login
+```
+
+Critical = no CLI (sandbox workflow requires it), or no auth (can't do anything without it), or no sandbox support (CLI too old — must update).
+
+If MCP is missing but CLI is installed with sandbox support, note it and continue — CLI covers most operations. Recommend installing MCP for full capabilities (docs, validation).
+
+If a previous init exists, ask: **"I found an existing workspace profile. Do you want to update it or start fresh?"**
+
+---
+
+## Phase 2: Interactive Setup (guided Q&A)
+
+Ask these questions conversationally — don't dump them all at once. Group related questions together and adapt based on answers. Use `AskUserQuestion` for each group.
+
+### 2a. Workspace Selection
+
+List available workspaces (via CLI `xano workspace:list` or Meta API) and ask:
+
+> **Which workspace are we working with?**
+
+If only one exists, confirm it. If they've already specified one (e.g., in args), use that.
+
+Once selected, fetch basic workspace info (name, ID, instance URL) and the branch list. You need branches to ask the next questions.
+
+### 2b. CLI Profile Setup
+
+Sandbox commands (`xano sandbox *`) inherit the workspace and branch from the CLI profile — they do **not** accept `-w` or `-b` flags. Setting up a dedicated profile is essential for the sandbox workflow to target the correct workspace and branch.
+
+1. Run `xano profile list` to see existing profiles
+2. Check if any profile already targets this workspace (match by workspace ID)
+3. If a suitable profile exists, confirm with the user: **"I see profile `[name]` targeting workspace [id]. Should I use this, or create a new one?"**
+4. If the branch isn't set or is wrong on the existing profile, update it: `xano profile edit [name] -b [dev-branch]`
+5. If no suitable profile exists, create one:
+   ```bash
+   xano profile create [workspace-name-slug] -i [instance-url] -t $(xano profile token) -w [workspace-id] -b [dev-branch]
+   ```
+6. Store the profile name — it will be used with `-p [profile]` for all subsequent CLI commands in the playbook.
+
+**Important:** If the user's default profile already targets this workspace and branch, a dedicated profile isn't strictly necessary, but is still recommended for clarity — especially if they work across multiple workspaces.
+
+### 2c. App Status & Stage
+
+> **What's the current status of this app?**
+> - 🚧 In active development (not yet live)
+> - 🟡 Staging/testing (has users but not fully launched)
+> - 🟢 Production (live with real users/data)
+> - 🔀 Mix (e.g., live but still adding major features)
+
+This determines how cautious development rules need to be.
+
+### 2d. Branching & Deployment
+
+Present what you found from the branch list, then ask:
+
+> **Here's what I see for branches: [list branches with live status]**
+>
+> - Which branch should I develop on?
+> - Are there any branches I should NEVER touch?
+
+Then present the deployment method choice. Lead with the sandbox recommendation:
+
+> For deploying changes, the **recommended approach is the sandbox workflow**: push changes to an isolated sandbox environment, review them in the browser, then promote to your development branch. The sandbox is fully isolated — nothing touches your real workspace or database until you explicitly promote.
+>
+> The alternative is `workspace push`, which pushes directly to a branch. Be aware: **schema changes (table modifications) take effect on the real database immediately**, even on a dev branch. This is why `workspace push` is disabled by default on Xano workspaces (`allow_push` must be explicitly enabled).
+>
+> Which approach do you prefer?
+> - **Sandbox workflow** (recommended — fully isolated, safe by default)
+> - **Direct workspace push** (faster iteration but riskier — requires enabling `allow_push` in workspace settings)
+> - **Something else** (CI/CD, manual in dashboard, etc.)
+
+If the user chooses workspace push, explain the risks clearly and confirm they understand. If they choose sandbox (or don't express a preference), proceed with sandbox as the default.
+
+### 2e. Team & Collaboration
+
+> **Who works on the Xano backend?**
+> - Just me
+> - Small team (2-5 people)
+> - Larger team with defined roles
+>
+> Are there any conventions I should follow? (naming, code style, PR process, etc.)
+
+### 2f. Development Boundaries
+
+> **Are there any no-go zones I should know about?**
+> - Tables I should never modify the schema of?
+> - Endpoints or functions I shouldn't touch?
+> - Environment variables that are sensitive or shouldn't be changed?
+> - Any integrations (webhooks, third-party services) I should be careful around?
+
+### 2g. Data Sources
+
+> **Do you use separate data sources for test vs. live data?**
+> - If yes: which data source should I use during development?
+> - If no: should I be careful about modifying data directly?
+
+### 2h. Editing & Validation Preferences
+
+This question focuses on **how to author code**, not how to deploy it (that was covered in 2d).
+
+> **How would you like me to author and edit Xano code?**
+> - Edit .xs files locally (pull → edit → push to sandbox)
+> - Via MCP tools for quick inline changes
+> - Some combination
+>
+> Should I always validate XanoScript before pushing to sandbox?
+
+If the user chose sandbox in 2d, the deployment workflow is already established — don't re-ask about it here.
+
+---
+
+## Phase 3: Workflow Validation (test that it works)
+
+Run quick smoke tests to confirm the development workflow actually functions. Do these in parallel where possible.
+
+### 3a. Validate XanoScript
+If there are existing `.xs` files, pick one and run `mcp__xano-developer__validate_xanoscript` to confirm validation works.
+
+### 3b. Test Deployment Access
+Make a read-only Meta API call (e.g., list API groups) to confirm the auth token and instance URL work for the workspace.
+
+### 3c. Test Branch Access
+If the user specified a development branch, confirm it exists and is accessible.
+
+### 3d. Test Sandbox Access
+If the user chose the sandbox workflow (the default):
+- Run `xano sandbox get -p [profile]` to create or retrieve the sandbox environment
+- Verify it returns successfully with state "ok"
+- If it fails, troubleshoot: check the profile has the correct workspace ID and branch, check CLI version
+
+If the user opted for workspace push instead:
+- Run `xano workspace get [workspace-id]` and check if `Allow Push` is enabled
+- If disabled, inform the user: "Workspace push is disabled by default. You can enable it in your workspace settings in the Xano dashboard, or I can help you enable it. However, the sandbox workflow avoids this requirement entirely and is safer."
+
+### 3e. Report Validation Results
+
+```
+## Workflow Validation
+
+| Test                    | Result |
+|-------------------------|--------|
+| XanoScript validation   | ✅ Working / ⚠️ No .xs files to test / ❌ Failed |
+| Meta API access         | ✅ Connected / ❌ Auth error |
+| Dev branch access       | ✅ Confirmed / ➖ N/A (single branch) |
+| Sandbox environment     | ✅ Provisioned / ❌ Failed / ➖ N/A (using workspace push) |
+| CLI profile             | ✅ [profile] → workspace [id], branch [branch] |
+```
+
+If anything fails, troubleshoot with the user before proceeding.
+
+---
+
+## Phase 4: Generate Development Playbook
+
+Based on everything gathered, create a focused **development playbook** at `.claude/xano-workspace-profile.md`. This is NOT an architecture document — it's a set of operating instructions for how to develop safely.
+
+```markdown
+---
+workspace: [Name]
+workspace_id: [ID]
+instance: [subdomain.xano.io]
+cli_profile: [profile-name]
+generated: [ISO date]
+---
+
+# Xano Development Playbook: [Workspace Name]
+
+## Quick Reference
+
+| Key | Value |
+|-----|-------|
+| Workspace ID | [id] |
+| Instance | [url] |
+| CLI Profile | [profile-name] (use `-p [profile-name]` with all CLI commands) |
+| App Status | [Development / Staging / Production] |
+| Dev Branch | [branch name or "main/v1"] |
+| Live Branch | [branch name or "same as dev"] |
+| Deploy Method | Sandbox (recommended) / [Workspace Push / Manual — only if user chose] |
+| Workspace Push | [Enabled / Disabled (default)] |
+| Data Source | [test / live / single] |
+
+## Development Rules
+
+[Generate 5-10 clear, specific rules based on the user's answers. These should be imperative statements. Lead with sandbox safety rules. Examples:]
+
+1. Always deploy via sandbox: `sandbox push` → `sandbox review` → promote. Never push directly to workspace.
+2. Always work on the `dev` branch — never modify the live branch directly
+3. Always use `-p [profile]` with CLI commands to target the correct workspace and branch
+4. Validate all XanoScript with `validate_xanoscript` before pushing to sandbox
+5. Never modify the `user` or `account` table schemas — they're in production
+6. Run `sandbox unit_test run_all` before promoting changes
+7. If sandbox gets into a bad state, reset with `sandbox reset -p [profile] -f`
+8. [etc. — based on actual user answers]
+
+If the user opted for workspace push instead of sandbox, adjust rules accordingly but include a clear warning about schema changes hitting the real database.
+
+## How to Deploy Changes
+
+### Sandbox Workflow (default)
+
+#### Editing an existing endpoint or function
+1. Pull workspace locally: `xano workspace pull ./xano -p [profile] -b [dev-branch]`
+2. Edit the relevant `.xs` files
+3. Validate: use `validate_xanoscript` MCP tool
+4. Push to sandbox: `xano sandbox push ./xano -p [profile]`
+5. Run tests in sandbox: `xano sandbox unit_test run_all -p [profile]`
+6. Review in browser: `xano sandbox review -p [profile]`
+7. Promote changes from sandbox to the dev branch via the review UI
+8. Pull updated state: `xano workspace pull ./xano -p [profile] -b [dev-branch]`
+
+#### Creating a new endpoint or function
+1. Create the `.xs` file locally following existing workspace patterns
+2. Validate the XanoScript
+3. Push to sandbox: `xano sandbox push ./xano -p [profile]`
+4. Review and promote: `xano sandbox review -p [profile]`
+
+#### Resetting the sandbox
+If the sandbox gets into a bad state or you want a clean slate:
+```bash
+xano sandbox reset -p [profile] -f
+```
+
+#### Running tests in sandbox
+```bash
+xano sandbox unit_test run_all -p [profile]
+xano sandbox workflow_test run_all -p [profile]
+```
+
+#### Managing sandbox environment variables
+```bash
+xano sandbox env list -p [profile]
+xano sandbox env set KEY value -p [profile]
+xano sandbox env get_all -p [profile]
+```
+
+### Alternative: Workspace Push (only if user opted in)
+
+> ⚠️ **Warning:** `workspace push` pushes directly to the workspace branch. Schema changes (table adds/removes/modifications) take effect on the real database immediately, even on a dev branch. This is NOT isolated. `allow_push` must be enabled on the workspace (disabled by default as a safety guard).
+
+1. Pull workspace: `xano workspace pull ./xano -p [profile] -b [dev-branch]`
+2. Edit `.xs` files
+3. Validate XanoScript
+4. Preview changes: `xano workspace push ./xano -p [profile] -b [dev-branch] --dry-run`
+5. Push: `xano workspace push ./xano -p [profile] -b [dev-branch]`
+
+### Deploying to live
+1. [specific steps based on user's merge/promotion workflow]
+
+## No-Go Zones
+
+[List specific tables, endpoints, functions, or env vars the user said not to touch]
+
+- **Tables:** [list or "none specified"]
+- **Endpoints:** [list or "none specified"]
+- **Functions:** [list or "none specified"]
+- **Env Vars:** [list or "none specified"]
+
+## Team Conventions
+
+[Any naming conventions, code style rules, or collaboration norms]
+
+## Troubleshooting
+
+### If sandbox push fails
+- Check sandbox state: `xano sandbox get -p [profile]`
+- Reset if needed: `xano sandbox reset -p [profile] -f`
+- Re-push after reset
+- Ensure your CLI profile has the correct workspace ID and branch
+
+### If sandbox commands are not recognized
+- Your CLI may be outdated. Update with: `xano update` or `npm install -g @xano/cli`
+
+### If workspace push fails with "allow_push disabled"
+- `allow_push` is disabled by default on Xano workspaces as a safety guard
+- Enable in the Xano dashboard workspace settings, or via the Meta API
+- Consider using the sandbox workflow instead — it's safer and doesn't require enabling push
+
+### If validation passes but runtime fails
+[Known gotchas like where clause syntax, $auth.account_id issues]
+```
+
+Keep the playbook **concise and actionable**. Every line should be something that changes how you develop. No filler.
+
+---
+
+## Phase 5: Update CLAUDE.md
+
+Add or update a small Xano section in the project's `CLAUDE.md` that points to the playbook and lists the top 3-5 most critical rules. This ensures every future conversation loads the key constraints immediately.
+
+```markdown
+## Xano Backend
+
+- **Workspace:** [Name] (ID: [id]) on [instance]
+- **Status:** [Production/Development/etc.]
+- **CLI Profile:** `[profile-name]` (always use `-p [profile-name]`)
+- **Playbook:** See `.claude/xano-workspace-profile.md` for full development rules
+
+### Critical Rules
+1. Always use the sandbox workflow — `sandbox push` → `sandbox review` → promote. Never push directly to workspace.
+2. [Branch safety rule — e.g., never touch v1/live directly]
+3. [Most important data/schema constraint]
+4. Always validate XanoScript before pushing to sandbox
+5. [Other key constraint from user answers]
+```
+
+If CLAUDE.md already has a Xano section, update it rather than duplicating.
+
+---
+
+## Phase 6: Summary
+
+Present a brief summary to the user:
+
+1. Environment status (what's working)
+2. Workspace connected and status confirmed
+3. Where the playbook was saved
+4. The top 3 rules they should know
+5. Any recommendations (e.g., "You should create a dev branch", "Consider setting up separate data sources", "Your CLI is outdated")
+
+End with: **"You're all set. I'll follow the development playbook for all future Xano work in this project."**
+
+---
+
+## Important Behavioral Notes
+
+- **Sandbox is the default.** Always prescribe the sandbox workflow unless the user explicitly chooses workspace push or another method. If the user hasn't expressed a preference, default to sandbox.
+- **Explain why sandbox > workspace push** when relevant: workspace push hits the real branch immediately — schema changes (table adds/removes/modifications) affect the real database even on a dev branch. The sandbox is fully isolated: nothing touches the real workspace until the user promotes from the review UI.
+- **workspace push is disabled by default.** Do not guide the user through enabling `allow_push` unless they specifically ask for the workspace push workflow. If they do, explain the risks clearly.
+- **Sandbox commands use the profile.** Sandbox commands (`xano sandbox *`) inherit workspace and branch from the CLI profile. They do not accept `-w` or `-b` flags. This is why setting up a dedicated CLI profile with the correct workspace ID and branch is essential during init.
+- **Be conversational, not robotic.** Group questions naturally, don't interrogate.
+- **Adapt to answers.** If they say "just me, solo dev, early development" — skip team/collaboration questions and keep rules lightweight.
+- **Don't over-generate.** A solo dev on a pre-launch app doesn't need 15 safety rules. Scale the playbook to the actual risk level.
+- **Validate, don't assume.** If you see a branch called `live`, confirm with the user that it's actually the production branch.
+- **Respect existing setup.** If there's already a CLAUDE.md with Xano config, preserve what's there and augment it — don't overwrite.
+- **Tool priority:** MCP tools (`mcp__xano-developer__*`) → CLI (`xano` commands) → Meta API via curl → ask the user. Use MCP for docs/validation; use CLI for workspace/branch/function/sandbox operations. Both can coexist.
+- **Prescriptive but adaptable.** Default to sandbox, but respect the user's choice if they prefer workspace push or another method. The user has final say.
+- **If the user provides args** (e.g., `/xano-init workspace 43`), skip the workspace selection step and use the provided ID.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,16 @@ Add to your Claude Desktop configuration file:
 
 ## Xano Skills
 
-This repo also ships agent skills under `skills/` (starting with `xano-init`, a guided setup that profiles a Xano workspace and builds a sandbox-first development playbook). Skills are distributed via the open [Agent Skills standard](https://github.com/vercel-labs/skills) and install with a single `npx` command — no cloning or manual file copying.
+This repo ships two agent skills under `skills/`:
 
-**Recommended:** install `xano-init` globally into Claude Code:
+- **`xano-init`** — guided setup that profiles a Xano workspace and builds a sandbox-first development playbook
+- **`xanoscript-docs-expert`** — deep reference for working with XanoScript documentation and this MCP project's architecture
+
+**Using Claude Code inside this repo?** You already have both skills. They're committed to `.claude/skills/` and load automatically when Claude Code starts a session in this directory — no install step needed. Just invoke `xano-init` or `xanoscript-docs-expert` by name, or describe the task in natural language.
+
+**Using a different agent, or want the skills available in other projects?** Skills are distributed via the open [Agent Skills standard](https://github.com/vercel-labs/skills) and install with a single `npx` command — no cloning or manual file copying.
+
+Install `xano-init` globally into Claude Code:
 
 ```bash
 npx skills add xano-inc/xano-developer-mcp -s xano-init -a claude-code -g
@@ -93,9 +100,9 @@ npx skills add xano-inc/xano-developer-mcp -s xano-init \
   -a claude-code -a codex -a cursor -a opencode -g
 ```
 
-Drop `-s` to install every skill in the repo, or `-g` to scope the install to the current project instead of your user profile. Other supported agents include `gemini-cli`, `windsurf`, `continue`, `cline`, `github-copilot`, and more — see the [skills CLI](https://github.com/vercel-labs/skills) for the full list.
+Drop `-s` to install every skill in the repo, or drop `-g` to scope the install to the current project instead of your user profile. Other supported agents include `gemini-cli`, `windsurf`, `continue`, `cline`, `github-copilot`, and more — see the [skills CLI](https://github.com/vercel-labs/skills) for the full list.
 
-Start a new agent session after installing so the skill manifest is picked up. Once loaded, invoke `xano-init` by name (e.g. `/xano-init` in Claude Code) or by asking your agent to *"set up this Xano workspace for development."*
+Start a new agent session after installing so the skill manifest is picked up.
 
 ## Checking Your Version
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ Add to your Claude Desktop configuration file:
 }
 ```
 
+## Xano Skills
+
+This repo also ships agent skills under `skills/` (starting with `xano-init`, a guided setup that profiles a Xano workspace and builds a sandbox-first development playbook). Skills are distributed via the open [Agent Skills standard](https://github.com/vercel-labs/skills) and install with a single `npx` command — no cloning or manual file copying.
+
+**Recommended:** install `xano-init` globally into Claude Code:
+
+```bash
+npx skills add xano-inc/xano-developer-mcp -s xano-init -a claude-code -g
+```
+
+Install into multiple agents at once (Claude Code, Codex, Cursor, OpenCode, etc.):
+
+```bash
+npx skills add xano-inc/xano-developer-mcp -s xano-init \
+  -a claude-code -a codex -a cursor -a opencode -g
+```
+
+Drop `-s` to install every skill in the repo, or `-g` to scope the install to the current project instead of your user profile. Other supported agents include `gemini-cli`, `windsurf`, `continue`, `cline`, `github-copilot`, and more — see the [skills CLI](https://github.com/vercel-labs/skills) for the full list.
+
+Start a new agent session after installing so the skill manifest is picked up. Once loaded, invoke `xano-init` by name (e.g. `/xano-init` in Claude Code) or by asking your agent to *"set up this Xano workspace for development."*
+
 ## Checking Your Version
 
 ```bash

--- a/skills/xanoscript-docs-expert/SKILL.md
+++ b/skills/xanoscript-docs-expert/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: xanoscript-docs-expert
+description: Expert skill for understanding, using, and modifying the xanoscript_docs documentation system in the xano-developer-mcp project. Use this skill whenever working with XanoScript documentation files (.md files in src/xanoscript_docs/), modifying the xanoscript_docs MCP tool, adding new documentation topics, editing existing docs, updating the topic registry in xanoscript.ts, or changing how documentation is served. Also use when someone asks about the xano-developer-mcp project architecture, the MCP server setup, or how the documentation delivery system works. Trigger on any mention of xanoscript_docs, XanoScript documentation, Xano MCP tools, or documentation authoring for this project.
+---
+
+# XanoScript Docs Expert
+
+## Overview
+
+This skill provides expert-level knowledge for working with the `xanoscript_docs` system inside the `@xano/developer-mcp` project. The project is a dual-purpose npm package: an MCP Server that serves XanoScript documentation to AI assistants, and a standalone library. The documentation lives as markdown files in `src/xanoscript_docs/` and is the primary content delivered by the `xanoscript_docs` MCP tool.
+
+## Architecture at a Glance
+
+```
+src/
+├── index.ts                    # MCP server entry (stdio transport)
+├── lib.ts                      # Library entry (standalone usage)
+├── xanoscript.ts               # Core doc logic: topic registry, file matching, content extraction
+├── tools/
+│   ├── index.ts                # Tool registry + dispatch (6 tools total)
+│   ├── xanoscript_docs.ts      # xanoscript_docs tool: path resolution, MCP definition
+│   ├── validate_xanoscript.ts  # Code validation via language server parser
+│   ├── meta_api_docs.ts        # Meta API docs tool
+│   ├── run_api_docs.ts         # Run API docs tool
+│   ├── cli_docs.ts             # CLI docs tool
+│   ├── mcp_version.ts          # Version tool
+│   └── types.ts                # Shared ToolResult type
+├── xanoscript_docs/            # 34 documentation topics (THE CONTENT)
+│   ├── README.md               # Overview (returned when no args)
+│   ├── version.json            # { "version": "2.0.0", "updated": "2025-02-06" }
+│   ├── docs_index.json         # Machine-readable index with aliases, filters, constructs
+│   ├── cheatsheet.md, syntax.md, quickstart.md, types.md  # Core language docs
+│   ├── functions.md, database.md, tables.md, apis.md      # Construct-specific docs
+│   ├── agents.md, tools.md, mcp-servers.md, triggers.md   # AI & event docs
+│   ├── [16 more topic files...]
+│   └── integrations/           # Sub-topic directory
+│       ├── cloud-storage.md, search.md, redis.md
+│       ├── external-apis.md, utilities.md
+│   ...
+├── meta_api_docs/              # Separate doc module for Meta API
+├── run_api_docs/               # Separate doc module for Run API
+└── cli_docs/                   # Separate doc module for CLI
+```
+
+## How the xanoscript_docs Tool Works
+
+### Request Flow
+
+```
+Caller provides { topic?, file_path?, mode? }
+    │
+    ├── No args → Return README.md
+    ├── topic="syntax" → Return syntax.md content
+    ├── file_path="api/users/create.xs" → minimatch applyTo patterns → return all matching docs
+    └── mode="quick_reference" → Extract only "## Quick Reference" sections
+    │
+    └── All responses append: "---\nDocumentation version: X.X.X"
+```
+
+### Key Source Files
+
+**`src/xanoscript.ts`** — The brain of the system:
+- `XANOSCRIPT_DOCS_V2`: Record<string, DocConfig> mapping 34 topic keys to `{ file, applyTo, description }`
+- `getDocsForFilePath(filePath)`: Uses `minimatch` to match file paths against `applyTo` glob patterns. Always includes "syntax" as a foundation topic.
+- `extractQuickReference(content, topic)`: Finds "## Quick Reference" heading and extracts content until the next `## ` heading. Falls back to first 50 lines.
+- `readXanoscriptDocsV2(docsPath, args)`: Main read function — decides what to return based on args.
+
+**`src/tools/xanoscript_docs.ts`** — The tool wrapper:
+- `getXanoscriptDocsPath()`: Resolves docs directory — tries `dist/xanoscript_docs/` first, falls back to `src/xanoscript_docs/`.
+- `xanoscriptDocs(args)`: Standalone function returning `{ documentation: string }`.
+- `xanoscriptDocsTool(args)`: Returns `ToolResult` (`{ success, data?, error? }`).
+- `xanoscriptDocsToolDefinition`: MCP tool schema with name, description, inputSchema.
+
+**`src/tools/index.ts`** — Registration:
+- `toolDefinitions` array registers all 6 tools
+- `handleTool(name, args)` dispatches by tool name
+- `toMcpResponse()` converts ToolResult to MCP format: `{ content: [{ type: "text", text }], isError? }`
+
+### Build Process
+
+```bash
+tsc && cp -r src/xanoscript_docs dist/
+```
+
+TypeScript compiles to `dist/`, then markdown files are copied verbatim. The docs are NOT transformed — they ship as-is.
+
+## Adding a New Documentation Topic
+
+This is the most common modification. Follow these steps exactly:
+
+### Step 1: Create the Markdown File
+
+Create a new `.md` file in `src/xanoscript_docs/`. For sub-topics, use the `integrations/` subdirectory pattern.
+
+Every doc file MUST start with frontmatter:
+
+```markdown
+---
+applyTo: "function/*.xs, api/**/*.xs"
+---
+```
+
+The `applyTo` value specifies which file patterns this doc applies to when using context-aware delivery. Use empty string or omit patterns for docs only accessible via explicit `topic` parameter.
+
+### Step 2: Register the Topic in `src/xanoscript.ts`
+
+Add an entry to the `XANOSCRIPT_DOCS_V2` object:
+
+```typescript
+"my-new-topic": {
+  file: "my-new-topic.md",           // Path relative to xanoscript_docs/
+  applyTo: ["function/**/*.xs"],        // Glob patterns for context-aware matching
+  description: "One-line description of what this doc covers",
+},
+```
+
+For sub-topics in a directory:
+```typescript
+"integrations/my-service": {
+  file: "integrations/my-service.md",
+  applyTo: [],                        // Sub-topics typically have empty applyTo
+  description: "Description here",
+},
+```
+
+### Step 3: Update `docs_index.json` (Optional but Recommended)
+
+Add the topic to `src/xanoscript_docs/docs_index.json` in the appropriate section:
+
+```json
+"my-new-topic": {
+  "file": "my-new-topic.md",
+  "purpose": "Brief purpose description",
+  "aliases": ["alias1", "alias2"]
+}
+```
+
+Also update `constructs`, `operations`, or `tasks` sections if the new topic documents any of those.
+
+### Step 4: Bump Version
+
+Update `src/xanoscript_docs/version.json`:
+```json
+{
+  "version": "2.1.0",
+  "updated": "2025-03-15"
+}
+```
+
+### Step 5: Build and Test
+
+```bash
+npm run build    # tsc && cp -r src/xanoscript_docs dist/
+npm test         # vitest run
+```
+
+## Documentation Authoring Conventions
+
+Read `references/doc-conventions.md` for the complete style guide. Here's the essential pattern:
+
+### Required Structure
+
+Every documentation file follows this skeleton:
+
+```markdown
+---
+applyTo: "pattern/**/*.xs"
+---
+
+# Topic Title
+
+> **TL;DR:** One or two sentences summarizing the key concepts.
+
+## Quick Reference
+
+| Feature | Example | Notes |
+|---------|---------|-------|
+| ...     | ...     | ...   |
+
+## [Detailed Sections]
+
+### Basic Structure
+[Minimal working example]
+
+### Common Patterns
+[Real-world usage examples]
+
+### Common Mistakes
+
+❌ **Wrong:**
+```xs
+// incorrect code
+```
+
+✅ **Correct:**
+```xs
+// correct code
+```
+
+## Related Topics
+
+| Topic | Use For |
+|-------|---------|
+| [syntax](xanoscript_docs({ topic: "syntax" })) | Filters and operators |
+```
+
+### Code Examples
+
+- Use `xs` language identifier for XanoScript code blocks
+- Use `javascript` for frontend code, `json` for data
+- Comments use `//` only (no `#` or `/* */` in XanoScript)
+- Show both wrong and correct patterns with ❌/✅ markers
+- Progress from simple to complex examples
+
+### Cross-Referencing
+
+Reference other topics using this pattern:
+```
+For details, see xanoscript_docs({ topic: "syntax" })
+For sub-topics: xanoscript_docs({ topic: "integrations/redis" })
+```
+
+### File Naming
+
+- Lowercase with hyphens: `unit-testing.md`, `cloud-storage.md`
+- Integration sub-topics go in `integrations/` subdirectory
+
+## XanoScript Language Reference
+
+For quick reference when writing docs, see `references/xanoscript-language.md`. Key things to remember:
+
+### Type Names (Common Mistake Area)
+
+| Correct | WRONG |
+|---------|-------|
+| `text` | `string` |
+| `int` | `integer` |
+| `decimal` | `float`, `number` |
+| `bool` | `boolean` |
+
+### Filter Type Safety (Most Common Doc Error)
+
+String filters and array filters are NOT interchangeable. This is the #1 source of mistakes in the docs:
+
+| Task | String Filter | Array Filter |
+|------|--------------|--------------|
+| Get length | `strlen` | `count` |
+| Get part | `substr` | `slice` |
+| Reverse | `split:""\|reverse\|join:""` | `reverse` |
+
+### Control Flow Keyword
+
+Always `elseif` (one word), never `else if`.
+
+### String Concatenation
+
+Use `~` (tilde), not `+`. Parentheses required around filtered values in concatenation:
+```xs
+($count|to_text) ~ " items"
+```
+
+## Modifying the MCP Tool Itself
+
+For changes to how documentation is served (not the content):
+
+### Changing Tool Parameters
+Edit `xanoscriptDocsToolDefinition` in `src/tools/xanoscript_docs.ts`. The `inputSchema` follows JSON Schema format.
+
+### Changing Doc Resolution Logic
+Edit functions in `src/xanoscript.ts`:
+- `getDocsForFilePath()` — context-aware matching logic
+- `extractQuickReference()` — quick reference extraction
+- `readXanoscriptDocsV2()` — main read dispatch
+
+### Changing Path Resolution
+Edit `getXanoscriptDocsPath()` in `src/tools/xanoscript_docs.ts`. The fallback chain: `dist/xanoscript_docs/` → `src/xanoscript_docs/` → default.
+
+### Adding a New MCP Tool
+1. Create `src/tools/my_tool.ts` with tool definition and handler
+2. Register in `src/tools/index.ts`: add to `toolDefinitions` array and `handleTool` switch
+3. Export from `src/lib.ts` if needed for standalone usage
+
+## Testing
+
+```bash
+npm test                    # Run all tests
+npm run test:watch          # Watch mode
+npm run test:coverage       # With V8 coverage
+```
+
+Test files live alongside source: `src/xanoscript.test.ts`. Tests use Vitest with `describe`/`it`/`expect` patterns.
+
+Key things to test when modifying docs:
+- New topics resolve correctly via `readXanoscriptDocsV2({ topic: "new-topic" })`
+- `applyTo` patterns match expected file paths via `getDocsForFilePath()`
+- Quick reference extraction works if your doc has a `## Quick Reference` section
+
+## Common Tasks Checklist
+
+| Task | Files to Modify |
+|------|----------------|
+| Add new doc topic | New `.md` file + `xanoscript.ts` (XANOSCRIPT_DOCS_V2) + optionally `docs_index.json` |
+| Edit existing doc content | Just the `.md` file in `src/xanoscript_docs/` |
+| Change which files a doc applies to | `xanoscript.ts` → topic's `applyTo` array |
+| Add integration sub-topic | New file in `integrations/` + register in `xanoscript.ts` |
+| Change tool description/schema | `src/tools/xanoscript_docs.ts` → `xanoscriptDocsToolDefinition` |
+| Change doc resolution logic | `src/xanoscript.ts` → `readXanoscriptDocsV2()` or `getDocsForFilePath()` |
+| Update version | `src/xanoscript_docs/version.json` |
+| Add new MCP tool (non-docs) | New file in `src/tools/` + register in `src/tools/index.ts` |

--- a/skills/xanoscript-docs-expert/references/doc-conventions.md
+++ b/skills/xanoscript-docs-expert/references/doc-conventions.md
@@ -1,0 +1,408 @@
+# Documentation Authoring Conventions
+
+Complete style guide for writing and editing XanoScript documentation files in `src/xanoscript_docs/`.
+
+## Table of Contents
+
+- [File Structure](#file-structure)
+- [Frontmatter](#frontmatter)
+- [Content Organization](#content-organization)
+- [Code Examples](#code-examples)
+- [Tables and Quick References](#tables-and-quick-references)
+- [Cross-Referencing](#cross-referencing)
+- [Common Mistakes Sections](#common-mistakes-sections)
+- [Decision Trees](#decision-trees)
+- [Callouts and Warnings](#callouts-and-warnings)
+- [Voice and Tone](#voice-and-tone)
+- [Naming Conventions](#naming-conventions)
+- [Complete Topic Registry](#complete-topic-registry)
+
+## File Structure
+
+Every doc file follows this pattern:
+
+```markdown
+---
+applyTo: "pattern/**/*.xs"
+---
+
+# Topic Title
+
+> **TL;DR:** Concise summary (1-2 sentences).
+
+## Quick Reference
+
+[Tables with common operations]
+
+## Section Index
+
+| Section | Contents |
+|---------|----------|
+| [Section 1](#section-1) | What it covers |
+
+## Section 1: Basic Structure
+
+[Minimal working example with explanation]
+
+## Section 2: Common Patterns
+
+[Progressive complexity examples]
+
+## Section 3: Advanced Usage
+
+[Complex patterns, edge cases]
+
+## Common Mistakes
+
+[Wrong/correct pattern pairs]
+
+## Related Topics
+
+| Topic | Use For |
+|-------|---------|
+| [topic](xanoscript_docs({ topic: "name" })) | Description |
+```
+
+## Frontmatter
+
+Every file must begin with YAML frontmatter specifying `applyTo` glob patterns:
+
+```yaml
+---
+applyTo: "function/**/*.xs, api/**/*.xs, ai/tool/*.xs"
+---
+```
+
+Common patterns:
+- `"**/*.xs"` — applies to all XanoScript files (use for foundational docs like syntax, cheatsheet)
+- `"function/**/*.xs"` — applies to function definitions (supports subdirectories)
+- `"api/**/*.xs"` — applies to API endpoint definitions
+- `"table/*.xs"` — applies to table schemas (no subdirectories)
+- `"*/trigger/*.xs, ai/*/trigger/*.xs, realtime/trigger/*.xs"` — applies to all trigger types
+- `"ai/agent/*.xs"` — applies to AI agent definitions
+- `"ai/tool/*.xs"` — applies to AI tool definitions
+- `"ai/mcp_server/*.xs"` — applies to MCP server definitions
+- Empty/omitted — only accessible via explicit topic parameter (common for integration sub-topics)
+
+The frontmatter must match the `applyTo` array in `XANOSCRIPT_DOCS_V2` in `src/xanoscript.ts`.
+
+## Content Organization
+
+### TL;DR Header
+
+Always include immediately after the title:
+
+```markdown
+> **TL;DR:** XanoScript uses `db.query` for filtered lists, `db.get` for single records,
+> and `db.has` for existence checks. All operations return results via `as $variable`.
+```
+
+### Quick Reference Section
+
+This section is extracted by `extractQuickReference()` when `mode="quick_reference"` is used. Make it self-contained and useful on its own.
+
+Format as tables whenever possible:
+
+```markdown
+## Quick Reference
+
+| Operation | Syntax | Returns |
+|-----------|--------|---------|
+| Query records | `db.query "table" { where = ... } as $results` | Array of records |
+| Get single | `db.get "table" { field_name = "id", field_value = $id } as $record` | Single record or null |
+```
+
+### Section Progression
+
+1. **Quick Reference** — compact lookup tables
+2. **Basic Structure** — minimal working example
+3. **Key Properties/Fields** — property reference tables
+4. **Common Patterns** — real-world usage
+5. **Advanced** — complex or less common patterns
+6. **Common Mistakes** — anti-patterns with corrections
+7. **Related Topics** — cross-references
+
+## Code Examples
+
+### Language Identifiers
+
+- `xs` — XanoScript code (the primary language)
+- `javascript` — Frontend/client code
+- `json` — Data structures and configurations
+- `bash` — Shell commands (rare)
+
+### Comment Style
+
+XanoScript only supports `//` comments:
+
+```xs
+// This is the only comment style
+var $name { value = "hello" }  // Can be inline too
+```
+
+Never use `#`, `/* */`, or `<!-- -->` in XanoScript code blocks.
+
+### Example Format
+
+Show purpose, then code, then explanation if needed:
+
+```markdown
+### Paginated Query
+
+```xs
+db.query "product" {
+  where = $db.product.is_active == true
+  order = [{ field: created_at, direction: desc }]
+  paging = { limit: 20, offset: 0 }
+  return = { type: "list", paging: { page: 1, per_page: 25 } }
+} as $products
+```
+
+Returns products with pagination metadata.
+```
+
+### Progressive Complexity
+
+Start simple, build up:
+
+```markdown
+### Basic Query
+```xs
+db.query "user" {} as $users
+```
+
+### With Filtering
+```xs
+db.query "user" {
+  where = $db.user.is_active == true
+} as $users
+```
+
+### With Sorting and Pagination
+```xs
+db.query "user" {
+  where = $db.user.is_active == true
+  order = [{ field: created_at, direction: desc }]
+  paging = { limit: 20, offset: 0 }
+} as $users
+```
+```
+
+## Tables and Quick References
+
+Use markdown tables for structured data. Common formats:
+
+### Property Tables
+
+```markdown
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `where` | expression | No | Filter condition |
+| `order` | array | No | Sort specification |
+```
+
+### Feature Comparison Tables
+
+```markdown
+| Feature | Example | Result |
+|---------|---------|--------|
+| `trim` | `"  hi  "\|trim` | `"hi"` |
+| `to_lower` | `"HELLO"\|to_lower` | `"hello"` |
+```
+
+### Decision Tables
+
+```markdown
+| Need To... | Use | Example |
+|-----------|-----|---------|
+| Read single record | `db.get` | `db.get "user" { field_name = "id", field_value = 1 }` |
+| Read filtered list | `db.query` | `db.query "user" { where = ... }` |
+```
+
+## Cross-Referencing
+
+### To Other Topics
+
+```markdown
+For complete filter reference, see xanoscript_docs({ topic: "syntax" })
+```
+
+### To Sub-Topics
+
+```markdown
+For AWS S3 operations, see xanoscript_docs({ topic: "integrations/cloud-storage" })
+```
+
+### Related Topics Table
+
+Always end docs with:
+
+```markdown
+## Related Topics
+
+| Topic | Use For |
+|-------|---------|
+| [syntax](xanoscript_docs({ topic: "syntax" })) | Operators, filters, expressions |
+| [database](xanoscript_docs({ topic: "database" })) | All db.* operations |
+```
+
+## Common Mistakes Sections
+
+Use the ❌/✅ format consistently:
+
+```markdown
+## Common Mistakes
+
+### 1. Using Wrong Type Names
+
+❌ **Wrong:**
+```xs
+input {
+  string name    // "string" is not a valid type
+  integer age    // "integer" is not valid either
+}
+```
+
+✅ **Correct:**
+```xs
+input {
+  text name      // Use "text" not "string"
+  int age        // Use "int" not "integer"
+}
+```
+
+### 2. Using `else if` Instead of `elseif`
+
+❌ **Wrong:**
+```xs
+conditional {
+  if (`$x > 0`) { }
+  else if (`$x < 0`) { }   // Two words - will fail
+}
+```
+
+✅ **Correct:**
+```xs
+conditional {
+  if (`$x > 0`) { }
+  elseif (`$x < 0`) { }    // One word - correct
+}
+```
+```
+
+Always include a brief explanation of WHY it's wrong.
+
+## Decision Trees
+
+For choosing between multiple approaches, use ASCII tree format:
+
+```markdown
+Need to read data?
+├── Single record by known field? → `db.get`
+├── Check if record exists? → `db.has`
+└── Filtered list of records? → `db.query`
+
+Need to write data?
+├── New record? → `db.add`
+├── Update known fields? → `db.edit`
+├── Update dynamic fields? → `db.patch`
+└── Insert or update? → `db.add_or_edit`
+```
+
+## Callouts and Warnings
+
+Use blockquote format:
+
+```markdown
+> **TL;DR:** Summary text here.
+
+> **Important:** Critical information the reader must know.
+
+> **Note:** Additional context or tips.
+
+> **Warning:** Potential pitfalls or dangerous patterns.
+```
+
+## Voice and Tone
+
+- **Professional but accessible** — assume technical knowledge but explain XanoScript-specific concepts
+- **Pragmatic** — focus on "what works" with practical examples
+- **Concise** — TL;DR headers, quick references, bullet lists over paragraphs
+- **Code-first** — show code before explaining it
+- **Pattern-focused** — emphasize reusable patterns over exhaustive API reference
+
+### Word Choices
+
+- Say "filter" (not "method" or "function" for pipe operations)
+- Say "construct" (for top-level language features: table, function, query, etc.)
+- Say "stack" (for the execution block inside constructs)
+- Say "input block" (for parameter definitions)
+- Say "canonical" (for unique identifier/path segment)
+- Say "addon" (for reusable subqueries)
+
+## Naming Conventions
+
+### Files
+
+- Lowercase with hyphens: `unit-testing.md`, `cloud-storage.md`, `mcp-servers.md`
+- Integration sub-topics in `integrations/` subdirectory
+
+### XanoScript Code in Examples
+
+- Folders and files: `snake_case` — `user_profile.xs`, `get_all_users_get.xs`
+- Variables: `$snake_case` — `$user_data`, `$api_response`
+- One definition per file (never multiple tables/functions in one `.xs` file)
+
+### Reserved Variable Names
+
+These appear frequently in examples:
+- `$input` — input parameters
+- `$auth` — authenticated user context
+- `$env` — environment variables
+- `$db` — database field references (in queries)
+- `$this` — current item in loops/maps
+- `$result` — accumulator in reduce operations
+- `$response` — endpoint response
+- `$output` — function output
+- `$index` - reserved
+
+## Complete Topic Registry
+
+All 34 topics registered in `XANOSCRIPT_DOCS_V2`:
+
+| Key | File | ApplyTo Pattern | Category |
+|-----|------|----------------|----------|
+| `readme` | README.md | (none) | Overview |
+| `cheatsheet` | cheatsheet.md | `**/*.xs` | Core |
+| `syntax` | syntax.md | `**/*.xs` | Core |
+| `quickstart` | quickstart.md | `**/*.xs` | Core |
+| `types` | types.md | `function/**`, `api/**`, `ai/tool/*`, `ai/agent/*` | Core |
+| `tables` | tables.md | `table/*.xs` | Constructs |
+| `functions` | functions.md | `function/**/*.xs` | Constructs |
+| `apis` | apis.md | `api/**/*.xs` | Constructs |
+| `tasks` | tasks.md | `task/*.xs` | Constructs |
+| `triggers` | triggers.md | `*/trigger/*`, `ai/*/trigger/*`, `realtime/trigger/*` | Constructs |
+| `database` | database.md | `function/**`, `api/**`, `task/*`, `ai/tool/*` | Operations |
+| `agents` | agents.md | `ai/agent/*.xs` | AI |
+| `tools` | tools.md | `ai/tool/*.xs` | AI |
+| `mcp-servers` | mcp-servers.md | `ai/mcp_server/*.xs` | AI |
+| `unit-testing` | unit-testing.md | `function/**`, `api/**`, `middleware/*` | Testing |
+| `workflow-tests` | workflow-tests.md | `workflow_test/*.xs` | Testing |
+| `integrations` | integrations.md | `function/**`, `api/**`, `task/*` | Integrations |
+| `integrations/cloud-storage` | integrations/cloud-storage.md | (none) | Integrations |
+| `integrations/search` | integrations/search.md | (none) | Integrations |
+| `integrations/redis` | integrations/redis.md | (none) | Integrations |
+| `integrations/external-apis` | integrations/external-apis.md | (none) | Integrations |
+| `integrations/utilities` | integrations/utilities.md | (none) | Integrations |
+| `frontend` | frontend.md | `static/**/*` | Constructs |
+| `run` | run.md | `run/**/*.xs` | Constructs |
+| `addons` | addons.md | `addon/*.xs`, `function/**`, `api/**` | Constructs |
+| `debugging` | debugging.md | `**/*.xs` | Operations |
+| `performance` | performance.md | `function/**`, `api/**` | Best Practices |
+| `realtime` | realtime.md | `realtime/channel/*`, `realtime/trigger/*` | Operations |
+| `schema` | schema.md | `function/**`, `api/**` | Operations |
+| `security` | security.md | `function/**`, `api/**` | Best Practices |
+| `streaming` | streaming.md | `function/**`, `api/**` | Operations |
+| `middleware` | middleware.md | `middleware/*.xs` | Constructs |
+| `branch` | branch.md | `branch.xs` | Config |
+| `workspace` | workspace.md | `workspace/*.xs` | Config |

--- a/skills/xanoscript-docs-expert/references/xanoscript-language.md
+++ b/skills/xanoscript-docs-expert/references/xanoscript-language.md
@@ -1,0 +1,526 @@
+# XanoScript Language Quick Reference
+
+Reference for the XanoScript language itself — use when authoring documentation examples or verifying correctness.
+
+## Table of Contents
+
+- [Constructs](#constructs)
+- [Data Types](#data-types)
+- [Variables](#variables)
+- [Operators](#operators)
+- [Filter System](#filter-system)
+- [Control Flow](#control-flow)
+- [Error Handling](#error-handling)
+- [Database Operations](#database-operations)
+- [Input Blocks](#input-blocks)
+- [Expressions](#expressions)
+- [API Integration](#api-integration)
+- [AI Agents and Tools](#ai-agents-and-tools)
+- [Testing](#testing)
+- [Integrations](#integrations)
+
+## Constructs
+
+XanoScript uses block-based definitions. Each `.xs` file contains exactly one construct:
+
+```xs
+<construct> "<name>" {
+  input { ... }
+  stack { ... }
+  response = $result
+}
+```
+
+| Construct | File Pattern | Purpose |
+|-----------|-------------|---------|
+| `workspace` | `workspace/*.xs` | Workspace config |
+| `workspace_trigger` | `workspace/trigger/*.xs` | Workspace events |
+| `table` | `table/*.xs` | Database schema |
+| `table_trigger` | `table/trigger/*.xs` | Table CRUD events |
+| `api_group` + `query` | `api/**/*.xs` | HTTP endpoints |
+| `function` | `function/**/*.xs` | Reusable logic |
+| `task` | `task/*.xs` | Scheduled jobs |
+| `addon` | `addon/*.xs` | Reusable subqueries |
+| `middleware` | `middleware/*.xs` | Request interceptors |
+| `agent` | `ai/agent/*.xs` | AI agents |
+| `agent_trigger` | `ai/agent/trigger/*.xs` | Agent events |
+| `tool` | `ai/tool/*.xs` | AI tools |
+| `mcp_server` | `ai/mcp_server/*.xs` | MCP servers |
+| `mcp_server_trigger` | `ai/mcp_server/trigger/*.xs` | MCP tool calls |
+| `workflow_test` | `workflow_test/*.xs` | E2E tests |
+| `realtime_channel` | `realtime/channel/*.xs` | Realtime channels |
+| `realtime_trigger` | `realtime/trigger/*.xs` | Channel events |
+
+## Data Types
+
+### Correct Names (Critical)
+
+| Correct | WRONG (never use) |
+|---------|-------------------|
+| `text` | `string` |
+| `int` | `integer` |
+| `decimal` | `float`, `number` |
+| `bool` | `boolean` |
+
+### All Types
+
+**Primitives:** `text`, `int`, `decimal`, `bool`, `email`, `password`, `uuid`, `timestamp`, `date`, `json`
+
+**Collections:** `type[]` (arrays, e.g., `text[]`, `int[]`), `object` (with nested schema)
+
+**Special:** `vector`, `enum`
+
+**File types:** `file`, `image`, `video`, `audio`, `attachment`
+
+**Geo types:** `geo_point`, `geo_polygon`, `geo_linestring`
+
+### Type Modifiers
+
+```xs
+text name                   // Required
+text nickname?              // Nullable (can be null)
+text role?="user"           // Optional with default
+text[1:10] tags             // Array size constraints
+```
+
+## Variables
+
+### Access Patterns
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `$input.field` | Input parameters — **prefix required** | `$input.name` |
+| `$var.field` or `$field` | Stack variables — prefix is optional | `$var.total` or `$total` |
+| `$auth.id` | Authenticated user | `$auth.id`, `$auth.role` |
+| `$env.NAME` | Environment variables | `$env.API_KEY` |
+| `$db.table.field` | DB field reference (queries) | `$db.user.email` |
+| `$this` | Current item in loops/maps | `$this.name` |
+| `$result` | Accumulator in reduce | `$result + $$` |
+| `$$` | Shorthand for current item in filter expressions | `$items\|map:$$.name` |
+
+### Input vs. Variable Access (Critical Distinction)
+
+Inputs and stack variables have different access rules:
+
+- **Inputs** declared in the `input {}` block **must always use `$input.fieldname`**. There is no shorthand.
+- **Stack variables** declared with `var` can be accessed as `$var.fieldname` or just `$fieldname` — they are identical.
+
+```xs
+// Declared in input block
+input {
+  text name
+  int age
+}
+
+// ❌ Wrong — inputs cannot be referenced as bare variables
+var $greeting { value = "Hello, " ~ $name }   // $name is undefined
+
+// ✅ Correct — inputs require $input prefix
+var $greeting { value = "Hello, " ~ $input.name }
+```
+
+```xs
+// Declared as a stack variable
+var $total { value = 42 }
+
+// ✅ Both forms are valid and identical
+$var.total     // explicit prefix
+$total         // shorthand — same thing
+```
+
+### Reserved Names
+
+Cannot use as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`
+
+## Operators
+
+| Category | Operators | Notes |
+|----------|-----------|-------|
+| Comparison | `==`, `!=`, `>`, `<`, `>=`, `<=` | Standard |
+| Null-safe | `==?`, `!=?`, `>=?`, `<=?` | Ignore if null (DB queries) |
+| Logical | `&&`, `\|\|`, `!` | AND, OR, NOT |
+| Math | `+`, `-`, `*`, `/`, `%` | Arithmetic |
+| String concat | `~` | `"Hello " ~ $name` |
+| Nullish coalescing | `??` | `$val ?? "default"` |
+| Regex (DB) | `~`, `!~` | Match/not match |
+| JSON contains (DB) | `@>` | JSON containment |
+
+## Filter System
+
+### Pipe Syntax
+
+```xs
+$text|trim|to_lower|strlen
+$array|first|get:"name"
+($count|to_text) ~ " items"    // Parentheses required in expressions
+```
+
+### CRITICAL: Type-Specific Filters
+
+String and array filters are NOT interchangeable:
+
+| Task | String Filter | Array Filter |
+|------|--------------|--------------|
+| Get length | `strlen` | `count` |
+| Get part | `substr:0:3` | `slice:0:3` |
+| Reverse | `split:""\|reverse\|join:""` | `reverse` |
+| Contains | `contains:"text"` | `some:$$=="val"` |
+
+### Math Filters
+
+`add`, `subtract`, `multiply`, `divide`, `modulus`, `floor`, `ceil`, `round`, `abs`, `sqrt`, `pow`, `min`, `max`
+
+Array math: `sum`, `avg`, `product`, `array_min`, `array_max`
+
+Trig: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `deg2rad`, `rad2deg`
+
+### String Filters
+
+`trim`, `ltrim`, `rtrim`, `to_lower`, `to_upper`, `capitalize`, `strlen`, `substr`, `split`, `replace`, `contains`, `starts_with`, `ends_with`, `concat`
+
+Case-insensitive: `icontains`, `istarts_with`, `iends_with`, `iindex`
+
+Regex: `regex_matches`, `regex_get_first_match`, `regex_get_all_matches`, `regex_replace`
+
+### Array Filters
+
+`first`, `last`, `count`, `reverse`, `unique`, `flatten`, `shuffle`, `slice`, `push`, `pop`, `shift`, `unshift`, `merge`, `diff`, `intersect`, `join`, `range`, `..`
+
+Functional: `map`, `filter`, `find`, `findIndex`, `some`, `every`, `reduce`
+
+Grouping: `index_by`, `sort`, `group_by`
+
+### Object Filters
+
+`get`, `set`, `unset`, `has`, `keys`, `values`, `entries`, `pick`, `unpick`
+
+Conditional: `set_conditional`, `set_ifnotempty`, `set_ifnotnull`
+
+### Type Conversion
+
+`to_int`, `to_decimal`, `to_text`, `to_bool`, `is_null`, `is_empty`, `is_array`, `is_object`, `is_int`, `is_text`
+
+Null handling: `first_notnull`, `first_notempty`
+
+### Date/Time Filters
+
+`to_timestamp`, `to_ms`, `to_seconds`, `format_timestamp`, `transform_timestamp`, `add_secs_to_timestamp`, `add_ms_to_timestamp`
+
+Extraction: `timestamp_year`, `timestamp_month`, `timestamp_day_of_month`, `timestamp_hour`, `timestamp_minute`, `timestamp_day_of_week`
+
+### Encoding Filters
+
+`json_encode`, `json_decode`, `base64_encode`, `base64_decode`, `url_encode`, `url_decode`, `xml_decode`, `yaml_encode`, `yaml_decode`, `hex2bin`, `bin2hex`
+
+### Security Filters
+
+`md5`, `sha1`, `sha256`, `sha512`, `hmac_sha256`, `encrypt`, `decrypt`, `jws_encode`, `jws_decode`, `jwe_encode`, `jwe_decode`, `secureid_encode`, `secureid_decode`, `uuid`
+
+### DB Query Filters
+
+`contains` (array), `includes` (string), `overlaps`, `between`, `within` (geo), `distance` (geo), `search_rank` (full-text), `cosine_similarity` (vector), `l2_distance_euclidean` (vector)
+
+### Domain Functions (Alternative Syntax)
+
+`text.contains()`, `text.starts_with()`, `text.ends_with()`, `text.icontains()`, `text.istarts_with()`, `text.iends_with()`
+
+`object.keys()`, `object.values()`, `object.entries()`
+
+`math.add()`, `math.sub()`, `math.mul()`, `math.div()`, `math.mod()`
+
+## Control Flow
+
+### Conditionals
+
+```xs
+conditional {
+  if (`$input.age >= 18`) {
+    var $status { value = "adult" }
+  }
+  elseif (`$input.age >= 13`) {    // ONE WORD: elseif
+    var $status { value = "teen" }
+  }
+  else {
+    var $status { value = "child" }
+  }
+}
+```
+
+Conditional as expression:
+```xs
+var $tier { value = conditional { if (`$level > 5`) { "premium" } else { "basic" } } }
+```
+
+### Loops
+
+```xs
+// forEach
+foreach ($items) {
+  each as $item {
+    debug.log { value = $item.name }
+  }
+}
+
+// For (iterate N times)
+for (10) {
+  each as $idx {
+    debug.log { value = $idx }
+  }
+}
+
+// While
+var $i { value = 0 }
+while ($i < 10) {
+  each { var.update $i { value = $i + 1 } }
+}
+
+// Switch
+switch ($input.action) {
+  case ("create") {
+    /* ... */
+  }
+
+  case ("update") break
+  default {
+    /* ... */
+  }
+}
+```
+
+Loop controls: `break`, `continue`, `remove` (deletes current item during iteration)
+
+### Early Return
+
+```xs
+conditional {
+  if (`$input.skip == true`) {
+    return { value = null }
+  }
+}
+```
+
+## Error Handling
+
+### Preconditions
+
+```xs
+precondition ($input.amount > 0) {
+  error_type = "inputerror"     // 400
+  error = "Amount must be positive"
+}
+```
+
+Error types: `inputerror` (400), `accessdenied` (403), `notfound` (404), `standard` (500)
+
+### Try-Catch
+
+```xs
+try_catch {
+  try {
+    api.request { url = "https://..." } as $result
+  }
+  catch {
+    debug.log { value = "Failed" }
+  }
+  finally {
+    debug.log { value = "Cleanup" }
+  }
+}
+```
+
+### Throw
+
+```xs
+throw {
+  name = "ValidationError"
+  value = "Custom error message"
+}
+```
+
+## Database Operations
+
+| Operation | Purpose | Returns |
+|-----------|---------|---------|
+| `db.query` | Filtered list | Array of records |
+| `db.get` | Single by field | Record or null |
+| `db.has` | Check existence | Boolean |
+| `db.add` | Insert | New record |
+| `db.edit` | Update (known fields) | Updated record |
+| `db.patch` | Update (dynamic fields) | Updated record |
+| `db.add_or_edit` | Upsert | Record |
+| `db.del` | Delete | void |
+| `db.truncate` | Delete all | void |
+
+### Where Clause Operators (DB-specific)
+
+```xs
+$db.user.name == "John"              // Equals
+$db.user.name includes "ohn"         // String contains
+$db.user.tags contains "admin"       // Array contains element
+$db.user.tags overlaps ["a", "b"]    // Arrays share elements
+$db.user.price between 10:100        // Range
+$db.user.geo within $point:1000      // Geo radius (meters)
+```
+
+## Input Blocks
+
+```xs
+input {
+  text name                          // Required
+  text nickname?                     // Optional (nullable)
+  text role?="user"                  // Optional with default
+  email contact filters=trim|lower   // With filters
+  text[] tags filters=trim           // Array type
+  object address {                   // Nested object
+    schema {
+      text street
+      text city
+    }
+  }
+}
+```
+
+Rules:
+- Empty input blocks: braces on separate lines
+- Single input: can be one-liner
+- Multiple inputs: each on own line
+
+## Expressions
+
+Expressions are evaluated inside backticks:
+
+```xs
+if (`$input.age >= 18`) { ... }
+var $total { value = `$input.qty * $input.price` }
+```
+
+String concatenation with `~`:
+```xs
+var $msg { value = "Hello, " ~ $input.name ~ "!" }
+var $info { value = ($status|to_text) ~ ": " ~ ($data|json_encode) }  // Parens required
+```
+
+## API Integration
+
+### External HTTP Requests
+
+```xs
+api.request {
+  url = "https://api.example.com/endpoint"
+  method = "POST"
+  params = $payload                  // NOTE: params = body (NOT query params)
+  headers = ["Content-Type: application/json", "Authorization: Bearer " ~ $env.API_KEY]
+} as $result
+
+// Response: $result.response.status, $result.response.result, $result.response.headers
+```
+
+### Internal Function Calls
+
+```xs
+function.run "math/calculate" {
+  input = { quantity: 5, price: 19.99 }
+} as $result
+```
+
+## AI Agents and Tools
+
+### Agent Definition
+
+```xs
+agent "Support Agent" {
+  canonical = "support-v1"
+  llm = {
+    type: "xano-free"          // or "openai", "anthropic", "google-genai"
+    system_prompt: "You are helpful"
+    prompt: "{{ $args.message }}"
+    max_steps: 5
+    temperature: 0.7
+  }
+  tools = [{ name: "lookup_order" }]
+}
+```
+
+### Tool Definition
+
+```xs
+tool "lookup_order" {
+  description = "Internal docs"       // NOT sent to AI
+  instructions = "How AI should use"  // Sent to AI
+  input {
+    int order_id { description = "The order ID to look up" }
+  }
+  stack { db.get "order" { field_name = "id", field_value = $input.order_id } as $order }
+  response = $order
+}
+```
+
+### Running Agents
+
+```xs
+ai.agent.run "Support Agent" {
+  args = {}|set:"message":$input.text
+  allow_tool_execution = true
+} as $agent_result
+```
+
+## Testing
+
+### Unit Tests (inside constructs)
+
+```xs
+test "calculates total correctly" {
+  input = { quantity: 5, price: 10 }
+  assert.to_equal { actual = $response.total, expected = 50 }
+}
+```
+
+Assertions: `to_equal`, `to_not_equal`, `to_be_true`, `to_be_false`, `to_be_null`, `to_not_be_null`, `to_contain`, `to_match`, `to_throw`, `to_be_greater_than`, `to_be_less_than`
+
+### Workflow Tests
+
+```xs
+workflow_test "user signup flow" {
+  stack {
+    api.call "auth/signup" {
+      input = { email: "test@test.com", password: "pass123" }
+    } as $signup
+    assert.to_equal { actual = $signup.response.status, expected = 200 }
+  }
+}
+```
+
+## Integrations
+
+### Cloud Storage
+
+```xs
+cloud.aws.s3.upload_file { key = $env.S3_KEY, secret = $env.S3_SECRET, bucket = "my-bucket", file_key = "path/file.txt", content = $data }
+cloud.azure.storage.upload_file { ... }
+cloud.google.storage.upload_file { ... }
+```
+
+### Redis
+
+```xs
+redis.set { key = "cache:user:1", value = $user|json_encode, ttl = 3600 }
+redis.get { key = "cache:user:1" } as $cached
+redis.ratelimit { key = "limit:ip:" ~ $env.$remote_ip, limit = 100, window = 60 } as $rate
+```
+
+### Search
+
+```xs
+cloud.elasticsearch.query { host = $env.ES_HOST, index = "products", query = { match: { name: $input.search } } } as $results
+cloud.algolia.search { app_id = $env.ALGOLIA_APP, api_key = $env.ALGOLIA_KEY, index = "products", query = $input.search } as $results
+```
+
+### Utilities
+
+```xs
+util.send_email { to = $user.email, subject = "Welcome", body = $template }
+security.create_auth_token { table = "user", id = $user.id, extras = {}, expiration = 86400 } as $token
+security.check_password { password = $input.password, hash = $user.password } as $valid
+zip.create { files = $file_list } as $archive
+api.lambda { runtime = "nodejs", code = "..." } as $result
+```


### PR DESCRIPTION
## Summary
- Adds a concise "Xano Skills" section to `README.md` covering installation of the `xano-init` skill via `npx skills add`
- Shows the recommended global Claude Code install plus a multi-agent variant
- Notes how to invoke the skill once loaded (e.g. `/xano-init` or natural language)

Follow-up to #40, which merged the skill itself — this PR adds the corresponding user-facing docs that didn't make it in before the merge.

## Test plan
- [ ] Render the README on GitHub and confirm the new section is well-formatted
- [ ] Verify the `npx skills add ...` command matches the Agent Skills CLI usage