### PR TITLE
Collapse multi-line where clauses in docs (1.0.75)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/xanoscript_docs/addons.md
+++ b/src/xanoscript_docs/addons.md
@@ -154,9 +154,7 @@ addon has_premium {
 
   stack {
     db.query subscription {
-      where = $db.subscription.user_id == $input.user_id
-            && $db.subscription.status == "active"
-            && $db.subscription.expires_at > now
+      where = $db.subscription.user_id == $input.user_id && $db.subscription.status == "active" && $db.subscription.expires_at > now
       return = {type: "exists"}
     }
   }

--- a/src/xanoscript_docs/security.md
+++ b/src/xanoscript_docs/security.md
@@ -54,9 +54,7 @@ Pattern: Store refresh tokens in a `refresh_token` table. On refresh, verify the
 ```xs
 // Key operations in a refresh flow:
 db.query "refresh_token" {
-  where = $db.refresh_token.token == $input.refresh_token
-        && $db.refresh_token.expires_at > now
-        && $db.refresh_token.revoked == false
+  where = $db.refresh_token.token == $input.refresh_token && $db.refresh_token.expires_at > now && $db.refresh_token.revoked == false
   return = { type: "single" }
 } as $stored_token
 
@@ -85,8 +83,7 @@ db.add "session" {
 
 // Validate session
 db.query "session" {
-  where = $db.session.id == $input.session_id
-        && $db.session.expires_at > now
+  where = $db.session.id == $input.session_id && $db.session.expires_at > now
   return = { type: "single" }
 } as $session
 ```

--- a/src/xanoscript_docs/syntax.md
+++ b/src/xanoscript_docs/syntax.md
@@ -355,9 +355,7 @@ Additional operators for `db.query` where clauses:
 
 ```xs
 db.query "product" {
-  where = $db.product.status not in ["deleted", "archived"]
-        && $db.product.metadata @> {"featured": true}
-        && $db.product.sku ~ "^SKU-[0-9]+"
+  where = $db.product.status not in ["deleted", "archived"] && $db.product.metadata @> {"featured": true} && $db.product.sku ~ "^SKU-[0-9]+"
 } as $products
 ```
 

--- a/src/xanoscript_docs/tasks.md
+++ b/src/xanoscript_docs/tasks.md
@@ -149,8 +149,7 @@ task "daily_digest" {
     foreach ($users) {
       each as $user {
         db.query "notification" {
-          where = $db.notification.user_id == $user.id
-            && $db.notification.sent == false
+          where = $db.notification.user_id == $user.id && $db.notification.sent == false
         } as $notifications
 
         conditional {

--- a/src/xanoscript_docs/tools.md
+++ b/src/xanoscript_docs/tools.md
@@ -194,9 +194,7 @@ tool "search_products" {
   }
   stack {
     db.query "product" {
-      where = $db.product.name includes? $input.query
-        && $db.product.category ==? $input.category
-        && $db.product.is_active == true
+      where = $db.product.name includes? $input.query && $db.product.category ==? $input.category && $db.product.is_active == true
       return = { type: "list", paging: { page: 1, per_page: $input.limit } }
     } as $products
   }


### PR DESCRIPTION
## Summary
- Collapse six multi-line `where` clauses across the XanoScript docs onto a single line — `&&` continuations were misleading as canonical examples
- Bump version to 1.0.75

## Files changed
- `src/xanoscript_docs/addons.md` (subscription check)
- `src/xanoscript_docs/syntax.md` (product status filter)
- `src/xanoscript_docs/tasks.md` (notification lookup)
- `src/xanoscript_docs/tools.md` (product search)
- `src/xanoscript_docs/security.md` (refresh token + session validation)
- `package.json` (1.0.74 → 1.0.75)

## Test plan
- [ ] Spot-check rendered docs on GitHub for the affected snippets
- [ ] `npm run build` succeeds and bundled docs copy contains the updated examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)