### PR TITLE
v2.0.0: McpServer migration, Zod source-of-truth, xano_ tool namespace

### DIFF
--- a/.claude/skills/xano-init/SKILL.md
+++ b/.claude/skills/xano-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xano-init
 description: Discover and profile a Xano workspace to understand how to develop safely with it using the sandbox workflow
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__xano-developer__meta_api_docs, mcp__xano-developer__cli_docs, mcp__xano-developer__xanoscript_docs, mcp__xano-developer__validate_xanoscript, mcp__xano-developer__mcp_version, WebFetch, ToolSearch, AskUserQuestion]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__xano__xano_meta_api_docs, mcp__xano__xano_cli_docs, mcp__xano__xano_xanoscript_docs, mcp__xano__xano_validate_xanoscript, mcp__xano__xano_version, WebFetch, ToolSearch, AskUserQuestion]
 ---
 
 # Xano Workspace Init
@@ -23,7 +23,7 @@ Run these checks silently before asking the user anything. Gather all results in
 - **Xano Developer MCP** npm package: `@xano/developer-mcp` — install: `claude mcp add xano -- npx -y @xano/developer-mcp`
 
 ### 1a. MCP Availability & Version
-- Use `ToolSearch` to check if `mcp__xano-developer__mcp_version` is available
+- Use `ToolSearch` to check if `mcp__xano__xano_version` is available
 - If available, call it to get the installed version
 - Run `npm view @xano/developer-mcp version` to get the latest published version
 - Compare: if installed < latest, flag as outdated
@@ -208,7 +208,7 @@ If the user chose sandbox in 2d, the deployment workflow is already established 
 Run quick smoke tests to confirm the development workflow actually functions. Do these in parallel where possible.
 
 ### 3a. Validate XanoScript
-If there are existing `.xs` files, pick one and run `mcp__xano-developer__validate_xanoscript` to confirm validation works.
+If there are existing `.xs` files, pick one and run `mcp__xano__xano_validate_xanoscript` to confirm validation works.
 
 ### 3b. Test Deployment Access
 Make a read-only Meta API call (e.g., list API groups) to confirm the auth token and instance URL work for the workspace.
@@ -280,7 +280,7 @@ generated: [ISO date]
 1. Always deploy via sandbox: `sandbox push` → `sandbox review` → promote. Never push directly to workspace.
 2. Always work on the `dev` branch — never modify the live branch directly
 3. Always use `-p [profile]` with CLI commands to target the correct workspace and branch
-4. Validate all XanoScript with `validate_xanoscript` before pushing to sandbox
+4. Validate all XanoScript with `xano_validate_xanoscript` before pushing to sandbox
 5. Never modify the `user` or `account` table schemas — they're in production
 6. Run `sandbox unit_test run_all` before promoting changes
 7. If sandbox gets into a bad state, reset with `sandbox reset -p [profile] -f`
@@ -295,7 +295,7 @@ If the user opted for workspace push instead of sandbox, adjust rules accordingl
 #### Editing an existing endpoint or function
 1. Pull workspace locally: `xano workspace pull ./xano -p [profile] -b [dev-branch]`
 2. Edit the relevant `.xs` files
-3. Validate: use `validate_xanoscript` MCP tool
+3. Validate: use `xano_validate_xanoscript` MCP tool
 4. Push to sandbox: `xano sandbox push ./xano -p [profile]`
 5. Run tests in sandbox: `xano sandbox unit_test run_all -p [profile]`
 6. Review in browser: `xano sandbox review -p [profile]`
@@ -426,6 +426,6 @@ End with: **"You're all set. I'll follow the development playbook for all future
 - **Don't over-generate.** A solo dev on a pre-launch app doesn't need 15 safety rules. Scale the playbook to the actual risk level.
 - **Validate, don't assume.** If you see a branch called `live`, confirm with the user that it's actually the production branch.
 - **Respect existing setup.** If there's already a CLAUDE.md with Xano config, preserve what's there and augment it — don't overwrite.
-- **Tool priority:** MCP tools (`mcp__xano-developer__*`) → CLI (`xano` commands) → Meta API via curl → ask the user. Use MCP for docs/validation; use CLI for workspace/branch/function/sandbox operations. Both can coexist.
+- **Tool priority:** MCP tools (`mcp__xano__xano_*`) → CLI (`xano` commands) → Meta API via curl → ask the user. Use MCP for docs/validation; use CLI for workspace/branch/function/sandbox operations. Both can coexist.
 - **Prescriptive but adaptable.** Default to sandbox, but respect the user's choice if they prefer workspace push or another method. The user has final say.
 - **If the user provides args** (e.g., `/xano-init workspace 43`), skip the workspace selection step and use the provided ID.

--- a/.claude/skills/xanoscript-docs-expert/SKILL.md
+++ b/.claude/skills/xanoscript-docs-expert/SKILL.md
@@ -69,11 +69,11 @@ Caller provides { topic?, file_path?, mode? }
 - `getXanoscriptDocsPath()`: Resolves docs directory — tries `dist/xanoscript_docs/` first, falls back to `src/xanoscript_docs/`.
 - `xanoscriptDocs(args)`: Standalone function returning `{ documentation: string }`.
 - `xanoscriptDocsTool(args)`: Returns `ToolResult` (`{ success, data?, error? }`).
-- `xanoscriptDocsToolDefinition`: MCP tool schema with name, description, inputSchema.
+- `xanoscriptDocsToolSpec`: Built via `defineTool({ inputShape, outputShape, ... })` — the Zod shapes are the single source of truth, and `xanoscriptDocsToolSpec.definition` exposes the derived JSON Schema for clients.
 
 **`src/tools/index.ts`** — Registration:
-- `toolDefinitions` array registers all 6 tools
-- `handleTool(name, args)` dispatches by tool name
+- `toolSpecs` map (5 tools) is the single source of truth used by `McpServer.registerTool` in `src/index.ts`
+- `handleTool(name, args)` is async and dispatches via a typed `dispatch` table keyed off `toolSpecs` — adding to `toolSpecs` without a handler is a compile error
 - `toMcpResponse()` converts ToolResult to MCP format: `{ content: [{ type: "text", text }], isError? }`
 
 ### Build Process
@@ -201,7 +201,7 @@ applyTo: "pattern/**/*.xs"
 
 | Topic | Use For |
 |-------|---------|
-| [syntax](xanoscript_docs({ topic: "syntax" })) | Filters and operators |
+| [syntax](xano_xanoscript_docs({ topic: "syntax" })) | Filters and operators |
 ```
 
 ### Code Examples
@@ -216,8 +216,8 @@ applyTo: "pattern/**/*.xs"
 
 Reference other topics using this pattern:
 ```
-For details, see xanoscript_docs({ topic: "syntax" })
-For sub-topics: xanoscript_docs({ topic: "integrations/redis" })
+For details, see xano_xanoscript_docs({ topic: "syntax" })
+For sub-topics: xano_xanoscript_docs({ topic: "integrations/redis" })
 ```
 
 ### File Naming
@@ -264,7 +264,7 @@ Use `~` (tilde), not `+`. Parentheses required around filtered values in concate
 For changes to how documentation is served (not the content):
 
 ### Changing Tool Parameters
-Edit `xanoscriptDocsToolDefinition` in `src/tools/xanoscript_docs.ts`. The `inputSchema` follows JSON Schema format.
+Edit `xanoscriptDocsToolSpec` in `src/tools/xanoscript_docs.ts`. Parameters live in the Zod `inputShape` (with `.describe()` for docs); the JSON Schema sent to MCP clients is derived automatically via `z.toJSONSchema`.
 
 ### Changing Doc Resolution Logic
 Edit functions in `src/xanoscript.ts`:
@@ -276,8 +276,8 @@ Edit functions in `src/xanoscript.ts`:
 Edit `getXanoscriptDocsPath()` in `src/tools/xanoscript_docs.ts`. The fallback chain: `dist/xanoscript_docs/` → `src/xanoscript_docs/` → default.
 
 ### Adding a New MCP Tool
-1. Create `src/tools/my_tool.ts` with tool definition and handler
-2. Register in `src/tools/index.ts`: add to `toolDefinitions` array and `handleTool` switch
+1. Create `src/tools/my_tool.ts` — build the spec with `defineTool({ name: "xano_my_tool", inputShape, outputShape, ... })` and export the handler
+2. Register in `src/tools/index.ts`: add to the `toolSpecs` map and the typed `dispatch` table (TypeScript will fail to compile if you forget the handler)
 3. Export from `src/lib.ts` if needed for standalone usage
 
 ## Testing
@@ -303,7 +303,7 @@ Key things to test when modifying docs:
 | Edit existing doc content | Just the `.md` file in `src/xanoscript_docs/` |
 | Change which files a doc applies to | `xanoscript.ts` → topic's `applyTo` array |
 | Add integration sub-topic | New file in `integrations/` + register in `xanoscript.ts` |
-| Change tool description/schema | `src/tools/xanoscript_docs.ts` → `xanoscriptDocsToolDefinition` |
+| Change tool description/schema | `src/tools/xanoscript_docs.ts` → `xanoscriptDocsToolSpec` (edit the Zod `inputShape` / `outputShape`) |
 | Change doc resolution logic | `src/xanoscript.ts` → `readXanoscriptDocsV2()` or `getDocsForFilePath()` |
 | Update version | `src/xanoscript_docs/version.json` |
-| Add new MCP tool (non-docs) | New file in `src/tools/` + register in `src/tools/index.ts` |
+| Add new MCP tool (non-docs) | New file in `src/tools/` (use `defineTool`) + add to `toolSpecs` and `dispatch` in `src/tools/index.ts` |

--- a/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
+++ b/.claude/skills/xanoscript-docs-expert/references/doc-conventions.md
@@ -60,7 +60,7 @@ applyTo: "pattern/**/*.xs"
 
 | Topic | Use For |
 |-------|---------|
-| [topic](xanoscript_docs({ topic: "name" })) | Description |
+| [topic](xano_xanoscript_docs({ topic: "name" })) | Description |
 ```
 
 ## Frontmatter
@@ -224,13 +224,13 @@ Use markdown tables for structured data. Common formats:
 ### To Other Topics
 
 ```markdown
-For complete filter reference, see xanoscript_docs({ topic: "syntax" })
+For complete filter reference, see xano_xanoscript_docs({ topic: "syntax" })
 ```
 
 ### To Sub-Topics
 
 ```markdown
-For AWS S3 operations, see xanoscript_docs({ topic: "integrations/cloud-storage" })
+For AWS S3 operations, see xano_xanoscript_docs({ topic: "integrations/cloud-storage" })
 ```
 
 ### Related Topics Table
@@ -242,8 +242,8 @@ Always end docs with:
 
 | Topic | Use For |
 |-------|---------|
-| [syntax](xanoscript_docs({ topic: "syntax" })) | Operators, filters, expressions |
-| [database](xanoscript_docs({ topic: "database" })) | All db.* operations |
+| [syntax](xano_xanoscript_docs({ topic: "syntax" })) | Operators, filters, expressions |
+| [database](xano_xanoscript_docs({ topic: "database" })) | All db.* operations |
 ```
 
 ## Common Mistakes Sections

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ import '@xano/developer-mcp/server';
 
 ## Available Tools
 
-### 1. `validate_xanoscript`
+### 1. `xano_validate_xanoscript`
 
 Validates XanoScript code for syntax errors. Supports multiple input methods. The language server auto-detects the object type from the code syntax.
 
@@ -341,24 +341,24 @@ Validates XanoScript code for syntax errors. Supports multiple input methods. Th
 **Examples:**
 ```
 // Validate code directly
-validate_xanoscript({ code: "var:result = 1 + 2" })
+xano_validate_xanoscript({ code: "var:result = 1 + 2" })
 
 // Validate a single file
-validate_xanoscript({ file_path: "function/utils/format.xs" })
+xano_validate_xanoscript({ file_path: "function/utils/format.xs" })
 
 // Validate multiple files
-validate_xanoscript({ file_paths: ["api/users/get.xs", "api/users/create.xs"] })
+xano_validate_xanoscript({ file_paths: ["api/users/get.xs", "api/users/create.xs"] })
 
 // Validate all .xs files in a directory
-validate_xanoscript({ directory: "api/users" })
+xano_validate_xanoscript({ directory: "api/users" })
 
 // Validate with a specific pattern
-validate_xanoscript({ directory: "src", pattern: "api/**/*.xs" })
+xano_validate_xanoscript({ directory: "src", pattern: "api/**/*.xs" })
 ```
 
 **Returns:** List of errors with line/column positions and helpful suggestions, or confirmation of validity.
 
-### 2. `xanoscript_docs`
+### 2. `xano_xanoscript_docs`
 
 Retrieves XanoScript programming language documentation with context-aware support.
 
@@ -416,37 +416,37 @@ Retrieves XanoScript programming language documentation with context-aware suppo
 **Examples:**
 ```
 // Get overview
-xanoscript_docs()
+xano_xanoscript_docs()
 
 // Get survival kit for small context models (~800 tokens)
-xanoscript_docs({ tier: "survival" })
+xano_xanoscript_docs({ tier: "survival" })
 
 // Get working reference for medium context models (~3500 tokens)
-xanoscript_docs({ tier: "working" })
+xano_xanoscript_docs({ tier: "working" })
 
 // Get essentials (recommended first stop)
-xanoscript_docs({ topic: "essentials" })
+xano_xanoscript_docs({ topic: "essentials" })
 
 // Get specific topic
-xanoscript_docs({ topic: "functions" })
+xano_xanoscript_docs({ topic: "functions" })
 
 // Discover available topics with sizes
-xanoscript_docs({ mode: "index" })
+xano_xanoscript_docs({ mode: "index" })
 
 // Budget-aware: load docs up to token limit
-xanoscript_docs({ file_path: "api/users/create_post.xs", max_tokens: 2000 })
+xano_xanoscript_docs({ file_path: "api/users/create_post.xs", max_tokens: 2000 })
 
 // Context-aware: get all docs relevant to file being edited
-xanoscript_docs({ file_path: "api/users/create_post.xs" })
+xano_xanoscript_docs({ file_path: "api/users/create_post.xs" })
 
 // Context-aware with exclusions (skip already-loaded topics)
-xanoscript_docs({ file_path: "api/users/create_post.xs", exclude_topics: ["syntax", "essentials"] })
+xano_xanoscript_docs({ file_path: "api/users/create_post.xs", exclude_topics: ["syntax", "essentials"] })
 
 // Compact quick reference (uses less context)
-xanoscript_docs({ topic: "database", mode: "quick_reference" })
+xano_xanoscript_docs({ topic: "database", mode: "quick_reference" })
 ```
 
-### 3. `mcp_version`
+### 3. `xano_version`
 
 Get the current version of the Xano Developer MCP server.
 
@@ -456,10 +456,10 @@ Get the current version of the Xano Developer MCP server.
 
 **Example:**
 ```
-mcp_version()
+xano_version()
 ```
 
-### 4. `meta_api_docs`
+### 4. `xano_meta_api_docs`
 
 Get documentation for Xano's Meta API. Use this to understand how to programmatically manage Xano workspaces, databases, APIs, functions, agents, and more.
 
@@ -495,19 +495,19 @@ Get documentation for Xano's Meta API. Use this to understand how to programmati
 **Examples:**
 ```
 // Get overview of Meta API
-meta_api_docs({ topic: "start" })
+xano_meta_api_docs({ topic: "start" })
 
 // Get detailed table documentation
-meta_api_docs({ topic: "table", detail_level: "detailed" })
+xano_meta_api_docs({ topic: "table", detail_level: "detailed" })
 
 // Get examples without schemas (smaller context)
-meta_api_docs({ topic: "api", detail_level: "examples", include_schemas: false })
+xano_meta_api_docs({ topic: "api", detail_level: "examples", include_schemas: false })
 
 // Step-by-step workflow guides
-meta_api_docs({ topic: "workflows" })
+xano_meta_api_docs({ topic: "workflows" })
 ```
 
-### 5. `cli_docs`
+### 5. `xano_cli_docs`
 
 Get documentation for the Xano CLI. The CLI is **optional but recommended** for local development workflows. Not all users will have it installed.
 
@@ -545,16 +545,16 @@ Use this tool to understand CLI commands for local development, code synchroniza
 **Examples:**
 ```
 // Get CLI setup guide
-cli_docs({ topic: "start" })
+xano_cli_docs({ topic: "start" })
 
 // Learn when to use CLI vs Meta API
-cli_docs({ topic: "integration" })
+xano_cli_docs({ topic: "integration" })
 
 // Get workspace sync commands
-cli_docs({ topic: "workspace", detail_level: "detailed" })
+xano_cli_docs({ topic: "workspace", detail_level: "detailed" })
 
 // Profile management with examples
-cli_docs({ topic: "profile", detail_level: "examples" })
+xano_cli_docs({ topic: "profile", detail_level: "examples" })
 ```
 
 ## MCP Resources
@@ -689,22 +689,22 @@ MCP Protocol (JSON-RPC over stdio)
     ▼
 Xano Developer MCP Server
     │
-    ├─► validate_xanoscript → Parses code with XanoScript language server
+    ├─► xano_validate_xanoscript → Parses code with XanoScript language server
     │
-    ├─► xanoscript_docs → Context-aware docs from /xanoscript_docs/*.md
+    ├─► xano_xanoscript_docs → Context-aware docs from /xanoscript_docs/*.md
     │
-    ├─► meta_api_docs → Meta API documentation with detail levels
+    ├─► xano_meta_api_docs → Meta API documentation with detail levels
     │
-    ├─► cli_docs → CLI documentation for local development workflows
+    ├─► xano_cli_docs → CLI documentation for local development workflows
     │
-    ├─► mcp_version → Returns server version from package.json
+    ├─► xano_version → Returns server version from package.json
     │
     └─► MCP Resources → Direct access to XanoScript documentation
 ```
 
 ## Authentication
 
-The MCP server and library functions do not require authentication. However, when using the documented APIs (Meta API) to interact with actual Xano services, you will need appropriate Xano API credentials. See the `meta_api_docs` tool for authentication details.
+The MCP server and library functions do not require authentication. However, when using the documented APIs (Meta API) to interact with actual Xano services, you will need appropriate Xano API credentials. See the `xano_meta_api_docs` tool for authentication details.
 
 ## Development
 
@@ -799,34 +799,51 @@ describe("myFunction", () => {
 
 ## Upgrading from 1.x to 2.0
 
-Version 2 modernizes the MCP server internals. The tools, MCP wire protocol, and
-the high-level standalone functions (`validateXanoscript`, `xanoscriptDocs`,
-`metaApiDocs`, `cliDocs`, `mcpVersion`) are unchanged — most users do not need
-to do anything beyond upgrading.
+Version 2 modernizes the MCP server internals and normalizes all tool names
+under a single `xano_` namespace. The high-level standalone library functions
+(`validateXanoscript`, `xanoscriptDocs`, `metaApiDocs`, `cliDocs`, `mcpVersion`)
+are unchanged.
 
-**Breaking changes affect only library consumers using `handleTool` directly:**
+### Tool renames (MCP clients)
 
-- `handleTool(name, args)` is now `async` and returns `Promise<ToolResult>` instead
-  of `ToolResult`. Add `await` at each call site.
+If your agent or MCP client config references tools by name, update them:
 
-  ```ts
-  // 1.x
-  const result = handleTool("xanoscript_docs", { topic: "syntax" });
+| 1.x | 2.0 |
+|---|---|
+| `validate_xanoscript` | `xano_validate_xanoscript` |
+| `xanoscript_docs` | `xano_xanoscript_docs` |
+| `meta_api_docs` | `xano_meta_api_docs` |
+| `cli_docs` | `xano_cli_docs` |
+| `mcp_version` | `xano_version` |
 
-  // 2.0
-  const result = await handleTool("xanoscript_docs", { topic: "syntax" });
-  ```
+The single `xano_` prefix improves discoverability when multiple MCP servers
+are installed and lets clients filter Xano tools by name pattern.
 
-**Notable fixes and additions in 2.0:**
+### Library API
 
-- `xanoscript_docs` now correctly accepts the documented `tier` and `max_tokens`
-  parameters — previously they were silently dropped before reaching the handler.
-- The server is built on the modern `McpServer` API with Zod-derived schemas, so
-  the JSON Schema published over the wire can no longer drift from the runtime
-  parser.
+`handleTool(name, args)` is now `async` and returns `Promise<ToolResult>`
+instead of `ToolResult`. Update call sites to use `await` and the new tool
+names:
+
+```ts
+// 1.x
+const result = handleTool("xanoscript_docs", { topic: "syntax" });
+
+// 2.0
+const result = await handleTool("xano_xanoscript_docs", { topic: "syntax" });
+```
+
+### Notable fixes and additions
+
+- `xano_xanoscript_docs` now correctly accepts the documented `tier` and
+  `max_tokens` parameters — previously they were silently dropped before
+  reaching the handler.
+- The server is built on the modern `McpServer` API with Zod-derived schemas,
+  so the JSON Schema published over the wire can no longer drift from the
+  runtime parser.
 - New `toolSpecs` export exposes each tool's Zod input/output shape — use it
   when registering tools in a custom `McpServer`.
-- `validate_xanoscript` results now include a `warnings` count in
+- `xano_validate_xanoscript` results now include a `warnings` count in
   `structuredContent` on success.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -833,6 +833,23 @@ const result = handleTool("xanoscript_docs", { topic: "syntax" });
 const result = await handleTool("xano_xanoscript_docs", { topic: "syntax" });
 ```
 
+The individual `*ToolDefinition` exports (`validateXanoscriptToolDefinition`,
+`xanoscriptDocsToolDefinition`, `mcpVersionToolDefinition`,
+`metaApiDocsToolDefinition`, `cliDocsToolDefinition`) were removed in favor
+of a single source of truth. Use `toolSpecs[name].definition` instead:
+
+```ts
+// 1.x
+import { validateXanoscriptToolDefinition } from "@xano/developer-mcp";
+
+// 2.0
+import { toolSpecs } from "@xano/developer-mcp";
+const validateXanoscriptToolDefinition =
+  toolSpecs.xano_validate_xanoscript.definition;
+```
+
+A new `ToolName` type export enumerates every registered tool name.
+
 ### Notable fixes and additions
 
 - `xano_xanoscript_docs` now correctly accepts the documented `tier` and

--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ console.log(`Using version ${version}`);
 | `metaApiDocs` | Get Meta API documentation |
 | `cliDocs` | Get CLI documentation |
 | `mcpVersion` | Get the package version |
-| `toolDefinitions` | MCP tool definitions (for building custom MCP servers) |
-| `handleTool` | Tool dispatcher function (for building custom MCP servers) |
+| `toolDefinitions` | MCP tool definitions (JSON Schema, for building custom MCP servers) |
+| `toolSpecs` | Tool specs with Zod input/output shapes (preferred for new code — works directly with `McpServer.registerTool`) |
+| `handleTool` | Async tool dispatcher (`Promise<ToolResult>`) for building custom MCP servers |
 
 ### TypeScript Support
 
@@ -795,6 +796,38 @@ describe("myFunction", () => {
   });
 });
 ```
+
+## Upgrading from 1.x to 2.0
+
+Version 2 modernizes the MCP server internals. The tools, MCP wire protocol, and
+the high-level standalone functions (`validateXanoscript`, `xanoscriptDocs`,
+`metaApiDocs`, `cliDocs`, `mcpVersion`) are unchanged — most users do not need
+to do anything beyond upgrading.
+
+**Breaking changes affect only library consumers using `handleTool` directly:**
+
+- `handleTool(name, args)` is now `async` and returns `Promise<ToolResult>` instead
+  of `ToolResult`. Add `await` at each call site.
+
+  ```ts
+  // 1.x
+  const result = handleTool("xanoscript_docs", { topic: "syntax" });
+
+  // 2.0
+  const result = await handleTool("xanoscript_docs", { topic: "syntax" });
+  ```
+
+**Notable fixes and additions in 2.0:**
+
+- `xanoscript_docs` now correctly accepts the documented `tier` and `max_tokens`
+  parameters — previously they were silently dropped before reaching the handler.
+- The server is built on the modern `McpServer` API with Zod-derived schemas, so
+  the JSON Schema published over the wire can no longer drift from the runtime
+  parser.
+- New `toolSpecs` export exposes each tool's Zod input/output shape — use it
+  when registering tools in a custom `McpServer`.
+- `validate_xanoscript` results now include a `warnings` count in
+  `structuredContent` on success.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "1.0.75",
+  "version": "2.0.0",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.0",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@xano/xanoscript-language-server": "^12.0.0",
-    "minimatch": "^10.1.2"
+    "minimatch": "^10.1.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/minimatch": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && cp -r src/xanoscript_docs dist/",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && cp -r src/xanoscript_docs dist/",
     "start": "node dist/index.js",
-    "dev": "tsc && node dist/index.js",
+    "dev": "npm run build && node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/skills/xano-init/SKILL.md
+++ b/skills/xano-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xano-init
 description: Discover and profile a Xano workspace to understand how to develop safely with it using the sandbox workflow
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__xano-developer__meta_api_docs, mcp__xano-developer__cli_docs, mcp__xano-developer__xanoscript_docs, mcp__xano-developer__validate_xanoscript, mcp__xano-developer__mcp_version, WebFetch, ToolSearch, AskUserQuestion]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__xano__xano_meta_api_docs, mcp__xano__xano_cli_docs, mcp__xano__xano_xanoscript_docs, mcp__xano__xano_validate_xanoscript, mcp__xano__xano_version, WebFetch, ToolSearch, AskUserQuestion]
 ---
 
 # Xano Workspace Init
@@ -23,7 +23,7 @@ Run these checks silently before asking the user anything. Gather all results in
 - **Xano Developer MCP** npm package: `@xano/developer-mcp` — install: `claude mcp add xano -- npx -y @xano/developer-mcp`
 
 ### 1a. MCP Availability & Version
-- Use `ToolSearch` to check if `mcp__xano-developer__mcp_version` is available
+- Use `ToolSearch` to check if `mcp__xano__xano_version` is available
 - If available, call it to get the installed version
 - Run `npm view @xano/developer-mcp version` to get the latest published version
 - Compare: if installed < latest, flag as outdated
@@ -208,7 +208,7 @@ If the user chose sandbox in 2d, the deployment workflow is already established 
 Run quick smoke tests to confirm the development workflow actually functions. Do these in parallel where possible.
 
 ### 3a. Validate XanoScript
-If there are existing `.xs` files, pick one and run `mcp__xano-developer__validate_xanoscript` to confirm validation works.
+If there are existing `.xs` files, pick one and run `mcp__xano__xano_validate_xanoscript` to confirm validation works.
 
 ### 3b. Test Deployment Access
 Make a read-only Meta API call (e.g., list API groups) to confirm the auth token and instance URL work for the workspace.
@@ -280,7 +280,7 @@ generated: [ISO date]
 1. Always deploy via sandbox: `sandbox push` → `sandbox review` → promote. Never push directly to workspace.
 2. Always work on the `dev` branch — never modify the live branch directly
 3. Always use `-p [profile]` with CLI commands to target the correct workspace and branch
-4. Validate all XanoScript with `validate_xanoscript` before pushing to sandbox
+4. Validate all XanoScript with `xano_validate_xanoscript` before pushing to sandbox
 5. Never modify the `user` or `account` table schemas — they're in production
 6. Run `sandbox unit_test run_all` before promoting changes
 7. If sandbox gets into a bad state, reset with `sandbox reset -p [profile] -f`
@@ -295,7 +295,7 @@ If the user opted for workspace push instead of sandbox, adjust rules accordingl
 #### Editing an existing endpoint or function
 1. Pull workspace locally: `xano workspace pull ./xano -p [profile] -b [dev-branch]`
 2. Edit the relevant `.xs` files
-3. Validate: use `validate_xanoscript` MCP tool
+3. Validate: use `xano_validate_xanoscript` MCP tool
 4. Push to sandbox: `xano sandbox push ./xano -p [profile]`
 5. Run tests in sandbox: `xano sandbox unit_test run_all -p [profile]`
 6. Review in browser: `xano sandbox review -p [profile]`
@@ -426,6 +426,6 @@ End with: **"You're all set. I'll follow the development playbook for all future
 - **Don't over-generate.** A solo dev on a pre-launch app doesn't need 15 safety rules. Scale the playbook to the actual risk level.
 - **Validate, don't assume.** If you see a branch called `live`, confirm with the user that it's actually the production branch.
 - **Respect existing setup.** If there's already a CLAUDE.md with Xano config, preserve what's there and augment it — don't overwrite.
-- **Tool priority:** MCP tools (`mcp__xano-developer__*`) → CLI (`xano` commands) → Meta API via curl → ask the user. Use MCP for docs/validation; use CLI for workspace/branch/function/sandbox operations. Both can coexist.
+- **Tool priority:** MCP tools (`mcp__xano__xano_*`) → CLI (`xano` commands) → Meta API via curl → ask the user. Use MCP for docs/validation; use CLI for workspace/branch/function/sandbox operations. Both can coexist.
 - **Prescriptive but adaptable.** Default to sandbox, but respect the user's choice if they prefer workspace push or another method. The user has final say.
 - **If the user provides args** (e.g., `/xano-init workspace 43`), skip the workspace selection step and use the provided ID.

--- a/skills/xanoscript-docs-expert/SKILL.md
+++ b/skills/xanoscript-docs-expert/SKILL.md
@@ -69,11 +69,11 @@ Caller provides { topic?, file_path?, mode? }
 - `getXanoscriptDocsPath()`: Resolves docs directory — tries `dist/xanoscript_docs/` first, falls back to `src/xanoscript_docs/`.
 - `xanoscriptDocs(args)`: Standalone function returning `{ documentation: string }`.
 - `xanoscriptDocsTool(args)`: Returns `ToolResult` (`{ success, data?, error? }`).
-- `xanoscriptDocsToolDefinition`: MCP tool schema with name, description, inputSchema.
+- `xanoscriptDocsToolSpec`: Built via `defineTool({ inputShape, outputShape, ... })` — the Zod shapes are the single source of truth, and `xanoscriptDocsToolSpec.definition` exposes the derived JSON Schema for clients.
 
 **`src/tools/index.ts`** — Registration:
-- `toolDefinitions` array registers all 6 tools
-- `handleTool(name, args)` dispatches by tool name
+- `toolSpecs` map (5 tools) is the single source of truth used by `McpServer.registerTool` in `src/index.ts`
+- `handleTool(name, args)` is async and dispatches via a typed `dispatch` table keyed off `toolSpecs` — adding to `toolSpecs` without a handler is a compile error
 - `toMcpResponse()` converts ToolResult to MCP format: `{ content: [{ type: "text", text }], isError? }`
 
 ### Build Process
@@ -201,7 +201,7 @@ applyTo: "pattern/**/*.xs"
 
 | Topic | Use For |
 |-------|---------|
-| [syntax](xanoscript_docs({ topic: "syntax" })) | Filters and operators |
+| [syntax](xano_xanoscript_docs({ topic: "syntax" })) | Filters and operators |
 ```
 
 ### Code Examples
@@ -216,8 +216,8 @@ applyTo: "pattern/**/*.xs"
 
 Reference other topics using this pattern:
 ```
-For details, see xanoscript_docs({ topic: "syntax" })
-For sub-topics: xanoscript_docs({ topic: "integrations/redis" })
+For details, see xano_xanoscript_docs({ topic: "syntax" })
+For sub-topics: xano_xanoscript_docs({ topic: "integrations/redis" })
 ```
 
 ### File Naming
@@ -264,7 +264,7 @@ Use `~` (tilde), not `+`. Parentheses required around filtered values in concate
 For changes to how documentation is served (not the content):
 
 ### Changing Tool Parameters
-Edit `xanoscriptDocsToolDefinition` in `src/tools/xanoscript_docs.ts`. The `inputSchema` follows JSON Schema format.
+Edit `xanoscriptDocsToolSpec` in `src/tools/xanoscript_docs.ts`. Parameters live in the Zod `inputShape` (with `.describe()` for docs); the JSON Schema sent to MCP clients is derived automatically via `z.toJSONSchema`.
 
 ### Changing Doc Resolution Logic
 Edit functions in `src/xanoscript.ts`:
@@ -276,8 +276,8 @@ Edit functions in `src/xanoscript.ts`:
 Edit `getXanoscriptDocsPath()` in `src/tools/xanoscript_docs.ts`. The fallback chain: `dist/xanoscript_docs/` → `src/xanoscript_docs/` → default.
 
 ### Adding a New MCP Tool
-1. Create `src/tools/my_tool.ts` with tool definition and handler
-2. Register in `src/tools/index.ts`: add to `toolDefinitions` array and `handleTool` switch
+1. Create `src/tools/my_tool.ts` — build the spec with `defineTool({ name: "xano_my_tool", inputShape, outputShape, ... })` and export the handler
+2. Register in `src/tools/index.ts`: add to the `toolSpecs` map and the typed `dispatch` table (TypeScript will fail to compile if you forget the handler)
 3. Export from `src/lib.ts` if needed for standalone usage
 
 ## Testing
@@ -303,7 +303,7 @@ Key things to test when modifying docs:
 | Edit existing doc content | Just the `.md` file in `src/xanoscript_docs/` |
 | Change which files a doc applies to | `xanoscript.ts` → topic's `applyTo` array |
 | Add integration sub-topic | New file in `integrations/` + register in `xanoscript.ts` |
-| Change tool description/schema | `src/tools/xanoscript_docs.ts` → `xanoscriptDocsToolDefinition` |
+| Change tool description/schema | `src/tools/xanoscript_docs.ts` → `xanoscriptDocsToolSpec` (edit the Zod `inputShape` / `outputShape`) |
 | Change doc resolution logic | `src/xanoscript.ts` → `readXanoscriptDocsV2()` or `getDocsForFilePath()` |
 | Update version | `src/xanoscript_docs/version.json` |
-| Add new MCP tool (non-docs) | New file in `src/tools/` + register in `src/tools/index.ts` |
+| Add new MCP tool (non-docs) | New file in `src/tools/` (use `defineTool`) + add to `toolSpecs` and `dispatch` in `src/tools/index.ts` |

--- a/skills/xanoscript-docs-expert/references/doc-conventions.md
+++ b/skills/xanoscript-docs-expert/references/doc-conventions.md
@@ -60,7 +60,7 @@ applyTo: "pattern/**/*.xs"
 
 | Topic | Use For |
 |-------|---------|
-| [topic](xanoscript_docs({ topic: "name" })) | Description |
+| [topic](xano_xanoscript_docs({ topic: "name" })) | Description |
 ```
 
 ## Frontmatter
@@ -224,13 +224,13 @@ Use markdown tables for structured data. Common formats:
 ### To Other Topics
 
 ```markdown
-For complete filter reference, see xanoscript_docs({ topic: "syntax" })
+For complete filter reference, see xano_xanoscript_docs({ topic: "syntax" })
 ```
 
 ### To Sub-Topics
 
 ```markdown
-For AWS S3 operations, see xanoscript_docs({ topic: "integrations/cloud-storage" })
+For AWS S3 operations, see xano_xanoscript_docs({ topic: "integrations/cloud-storage" })
 ```
 
 ### Related Topics Table
@@ -242,8 +242,8 @@ Always end docs with:
 
 | Topic | Use For |
 |-------|---------|
-| [syntax](xanoscript_docs({ topic: "syntax" })) | Operators, filters, expressions |
-| [database](xanoscript_docs({ topic: "database" })) | All db.* operations |
+| [syntax](xano_xanoscript_docs({ topic: "syntax" })) | Operators, filters, expressions |
+| [database](xano_xanoscript_docs({ topic: "database" })) | All db.* operations |
 ```
 
 ## Common Mistakes Sections

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -84,7 +84,7 @@ export function handleCliDocs(args: CliDocsArgs): string {
  * Tool definition for MCP server
  */
 export const cliDocsTool_spec = defineTool({
-  name: "cli_docs",
+  name: "xano_cli_docs",
   description: `Get documentation for the Xano CLI. Use this to understand how to use the CLI for local development, code sync, and XanoScript execution.
 
 ## Topics

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -5,8 +5,10 @@
  * the cli_docs tool handler for the MCP server.
  */
 
+import { z } from "zod";
 import type { TopicDoc, DetailLevel, CliDocsArgs } from "./types.js";
 import { formatDocumentation } from "./format.js";
+import { defineTool } from "../tools/define_tool.js";
 
 // Import all topic documentation
 import { authDoc } from "./topics/auth.js";
@@ -81,14 +83,8 @@ export function handleCliDocs(args: CliDocsArgs): string {
 /**
  * Tool definition for MCP server
  */
-export const cliDocsToolDefinition = {
+export const cliDocsTool_spec = defineTool({
   name: "cli_docs",
-  annotations: {
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
   description: `Get documentation for the Xano CLI. Use this to understand how to use the CLI for local development, code sync, and XanoScript execution.
 
 ## Topics
@@ -99,39 +95,35 @@ ${getTopicDescriptions()}
 - Use "auth" or "profile" to understand authentication options
 - Use "integration" to understand when to use CLI vs Meta API
 - Use specific topics for command reference (workspace, sandbox, branch, release, tenant, function, etc.)`,
-
-  inputSchema: {
-    type: "object",
-    properties: {
-      topic: {
-        type: "string",
-        enum: getTopicNames(),
-        description:
-          "Documentation topic to retrieve. Start with 'start' for installation and setup. " +
-          "Example: topic='function' for function management commands, topic='sandbox' for the personal dev environment.",
-      },
-      detail_level: {
-        type: "string",
-        enum: ["overview", "detailed", "examples"],
-        default: "detailed",
-        description:
-          "Level of detail to return. " +
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputShape: {
+    topic: z
+      .enum(getTopicNames() as [string, ...string[]])
+      .describe(
+        "Documentation topic to retrieve. Start with 'start' for installation and setup. " +
+          "Example: topic='function' for function management commands, topic='sandbox' for the personal dev environment."
+      ),
+    detail_level: z
+      .enum(["overview", "detailed", "examples"])
+      .optional()
+      .describe(
+        "Level of detail to return. " +
           "'overview' = brief summary of commands and their purpose. " +
           "'detailed' = full command reference with flags and arguments. " +
           "'examples' = includes usage examples for each command. " +
-          "Default: 'detailed'.",
-      },
-    },
-    required: ["topic"],
+          "Default: 'detailed'."
+      ),
   },
-  outputSchema: {
-    type: "object",
-    properties: {
-      documentation: {
-        type: "string",
-        description: "The CLI documentation content for the requested topic.",
-      },
-    },
-    required: ["documentation"],
+  outputShape: {
+    documentation: z
+      .string()
+      .describe("The CLI documentation content for the requested topic."),
   },
-};
+});
+
+export const cliDocsToolDefinition = cliDocsTool_spec.definition;

--- a/src/cli_docs/index.ts
+++ b/src/cli_docs/index.ts
@@ -83,7 +83,7 @@ export function handleCliDocs(args: CliDocsArgs): string {
 /**
  * Tool definition for MCP server
  */
-export const cliDocsTool_spec = defineTool({
+export const cliDocsToolSpec = defineTool({
   name: "xano_cli_docs",
   description: `Get documentation for the Xano CLI. Use this to understand how to use the CLI for local development, code sync, and XanoScript execution.
 
@@ -126,4 +126,3 @@ ${getTopicDescriptions()}
   },
 });
 
-export const cliDocsToolDefinition = cliDocsTool_spec.definition;

--- a/src/cli_docs/topics/integration.ts
+++ b/src/cli_docs/topics/integration.ts
@@ -107,7 +107,7 @@ curl -H "Authorization: Bearer $TOKEN" https://instance.xano.io/api:meta/workspa
         "Init git: `cd xano && git init && git add . && git commit -m 'Initial'`",
         "Create feature branch: `git checkout -b feature/new-api`",
         "Edit .xs files in your IDE",
-        "Validate with MCP: Use `validate_xanoscript` tool",
+        "Validate with MCP: Use `xano_validate_xanoscript` tool",
         "Push to Xano: `xano workspace push -d ./xano`",
         "Test in Xano dashboard",
         "Commit changes: `git add . && git commit -m 'Add new API'`"

--- a/src/cli_docs/topics/workspace.ts
+++ b/src/cli_docs/topics/workspace.ts
@@ -282,7 +282,7 @@ For lighter-weight iterative development without pulling the whole workspace, se
         "Pull workspace: `xano workspace pull -d ./code`",
         "Navigate to organized folders: `api/{group}/`, `function/`, `table/`, etc.",
         "Edit .xs files in your IDE (files use snake_case naming)",
-        "Validate changes: Use xanoscript_docs MCP tool",
+        "Validate changes: Use xano_xanoscript_docs MCP tool",
         "Push changes: `xano workspace push -d ./code`",
         "Test in Xano dashboard or via API"
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,21 +9,15 @@
  * ```
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  ListResourcesRequestSchema,
-  ReadResourceRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
 import { XANOSCRIPT_DOCS_V2, getXanoscriptDocsVersion } from "./xanoscript.js";
 import {
-  toolDefinitions,
+  toolSpecs,
   handleTool,
   toMcpResponse,
   getXanoscriptDocsPath,
@@ -40,90 +34,66 @@ if (process.argv.includes("--version") || process.argv.includes("-v")) {
   process.exit(0);
 }
 
-// =============================================================================
-// Path Resolution (uses shared path from tools/xanoscript_docs.ts)
-// =============================================================================
-
 const XANOSCRIPT_DOCS_PATH = getXanoscriptDocsPath();
 
 // =============================================================================
 // MCP Server Setup
 // =============================================================================
 
-const server = new Server(
-  {
-    name: "xano-developer-mcp",
-    version: SERVER_VERSION,
-    description:
-      "MCP server for Xano Headless API documentation and XanoScript code validation",
-  },
-  {
-    capabilities: {
-      tools: {},
-      resources: {},
+const server = new McpServer({
+  name: "xano-developer-mcp",
+  version: SERVER_VERSION,
+});
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+for (const spec of Object.values(toolSpecs)) {
+  server.registerTool(
+    spec.name,
+    {
+      description: spec.description,
+      annotations: spec.annotations,
+      inputSchema: spec.inputShape,
+      outputSchema: spec.outputShape,
     },
-  }
-);
+    // The SDK has already parsed/validated args against inputShape, but handleTool
+    // re-parses defensively so it can be used directly from library code too.
+    async (args: Record<string, unknown> | undefined) => {
+      const result = await handleTool(spec.name, args ?? {});
+      return toMcpResponse(result);
+    }
+  );
+}
 
 // =============================================================================
-// Resource Handlers (MCP Resources)
+// Resource Registration (XanoScript docs as MCP resources)
 // =============================================================================
 
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  const resources = Object.entries(XANOSCRIPT_DOCS_V2).map(([key, config]) => ({
-    uri: `xanoscript://docs/${key}`,
-    name: key,
-    description: config.description,
-    mimeType: "text/markdown",
-  }));
-
-  return { resources };
-});
-
-server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-  const { uri } = request.params;
-  const match = uri.match(/^xanoscript:\/\/docs\/(.+)$/);
-
-  if (!match) {
-    throw new Error(`Unknown resource URI: ${uri}`);
-  }
-
-  const topic = match[1];
-  const config = XANOSCRIPT_DOCS_V2[topic];
-
-  if (!config) {
-    throw new Error(
-      `Unknown topic: ${topic}. Available: ${Object.keys(XANOSCRIPT_DOCS_V2).join(", ")}`
-    );
-  }
-
-  const content = readFileSync(join(XANOSCRIPT_DOCS_PATH, config.file), "utf-8");
-  const version = getXanoscriptDocsVersion(XANOSCRIPT_DOCS_PATH);
-
-  return {
-    contents: [
-      {
-        uri,
-        mimeType: "text/markdown",
-        text: `${content}\n\n---\nDocumentation version: ${version}`,
-      },
-    ],
-  };
-});
-
-// =============================================================================
-// Tool Handlers
-// =============================================================================
-
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools: toolDefinitions };
-});
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  const result = handleTool(name, (args as Record<string, unknown>) || {});
-  return toMcpResponse(result);
-});
+for (const [key, config] of Object.entries(XANOSCRIPT_DOCS_V2)) {
+  server.registerResource(
+    key,
+    `xanoscript://docs/${key}`,
+    {
+      description: config.description,
+      mimeType: "text/markdown",
+    },
+    async (uri) => {
+      const content = readFileSync(join(XANOSCRIPT_DOCS_PATH, config.file), "utf-8");
+      const version = getXanoscriptDocsVersion(XANOSCRIPT_DOCS_PATH);
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "text/markdown",
+            text: `${content}\n\n---\nDocumentation version: ${version}`,
+          },
+        ],
+      };
+    }
+  );
+}
 
 // =============================================================================
 // Start Server

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,22 @@ for (const spec of Object.values(toolSpecs)) {
       inputSchema: spec.inputShape,
       outputSchema: spec.outputShape,
     },
-    // The SDK has already parsed/validated args against inputShape, but handleTool
-    // re-parses defensively so it can be used directly from library code too.
+    // The SDK validates args against `inputShape` before invoking; handleTool
+    // re-parses defensively so it's also safe to call from library code.
+    // Any thrown error is converted into a structured ToolResult so the client
+    // sees a useful message instead of a transport-level failure.
     async (args: Record<string, unknown> | undefined) => {
-      const result = await handleTool(spec.name, args ?? {});
-      return toMcpResponse(result);
+      try {
+        const result = await handleTool(spec.name, args ?? {});
+        return toMcpResponse(result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[${spec.name}] handler threw:`, error);
+        return toMcpResponse({
+          success: false,
+          error: `Internal error in ${spec.name}: ${message}`,
+        });
+      }
     }
   );
 }
@@ -72,25 +83,38 @@ for (const spec of Object.values(toolSpecs)) {
 // =============================================================================
 
 for (const [key, config] of Object.entries(XANOSCRIPT_DOCS_V2)) {
+  const resourceUri = `xanoscript://docs/${key}`;
   server.registerResource(
     key,
-    `xanoscript://docs/${key}`,
+    resourceUri,
     {
       description: config.description,
       mimeType: "text/markdown",
     },
     async (uri) => {
-      const content = readFileSync(join(XANOSCRIPT_DOCS_PATH, config.file), "utf-8");
-      const version = getXanoscriptDocsVersion(XANOSCRIPT_DOCS_PATH);
-      return {
-        contents: [
-          {
-            uri: uri.href,
-            mimeType: "text/markdown",
-            text: `${content}\n\n---\nDocumentation version: ${version}`,
-          },
-        ],
-      };
+      try {
+        const content = readFileSync(join(XANOSCRIPT_DOCS_PATH, config.file), "utf-8");
+        const version = getXanoscriptDocsVersion(XANOSCRIPT_DOCS_PATH);
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: "text/markdown",
+              text: `${content}\n\n---\nDocumentation version: ${version}`,
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[resource ${key}] Failed to read ${config.file} from ${XANOSCRIPT_DOCS_PATH}:`,
+          error
+        );
+        throw new Error(
+          `Failed to read XanoScript docs resource "${key}" (${uri.href}) ` +
+            `from ${join(XANOSCRIPT_DOCS_PATH, config.file)}: ${message}`
+        );
+      }
     }
   );
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -123,6 +123,7 @@ export {
 
 export {
   toolDefinitions,
+  toolSpecs,
   handleTool,
   validateXanoscriptToolDefinition,
   xanoscriptDocsToolDefinition,
@@ -130,3 +131,10 @@ export {
   metaApiDocsToolDefinition,
   cliDocsToolDefinition,
 } from "./tools/index.js";
+
+export type {
+  BuiltTool,
+  ToolDefinition,
+  ToolSpec,
+  ToolAnnotations,
+} from "./tools/define_tool.js";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -125,16 +125,14 @@ export {
   toolDefinitions,
   toolSpecs,
   handleTool,
-  validateXanoscriptToolDefinition,
-  xanoscriptDocsToolDefinition,
-  mcpVersionToolDefinition,
-  metaApiDocsToolDefinition,
-  cliDocsToolDefinition,
 } from "./tools/index.js";
+
+export type { ToolName } from "./tools/index.js";
 
 export type {
   BuiltTool,
   ToolDefinition,
   ToolSpec,
   ToolAnnotations,
+  JsonSchema,
 } from "./tools/define_tool.js";

--- a/src/meta_api_docs/format.test.ts
+++ b/src/meta_api_docs/format.test.ts
@@ -11,7 +11,7 @@ describe("meta_api_docs/format", () => {
       expect(META_API_CONFIG.baseUrlInfo).toContain(
         "https://<your-instance-subdomain>.xano.io/api:meta/"
       );
-      expect(META_API_CONFIG.toolName).toBe("meta_api_docs");
+      expect(META_API_CONFIG.toolName).toBe("xano_meta_api_docs");
     });
   });
 
@@ -235,7 +235,7 @@ describe("meta_api_docs/format", () => {
       const result = formatDocumentation(docWithRelated);
       expect(result).toContain("## Related Topics");
       expect(result).toContain("topic1, topic2, topic3");
-      expect(result).toContain("meta_api_docs");
+      expect(result).toContain("xano_meta_api_docs");
     });
 
     it("should use custom config", () => {

--- a/src/meta_api_docs/format.ts
+++ b/src/meta_api_docs/format.ts
@@ -22,7 +22,7 @@ https://<your-instance-subdomain>.xano.io/api:meta/<endpoint>
 \`\`\`
 Authorization: \`Bearer <your-access-token>\`
 `,
-  toolName: "meta_api_docs",
+  toolName: "xano_meta_api_docs",
 };
 
 function formatParameter(param: NonNullable<EndpointDoc["parameters"]>[0]): string {

--- a/src/meta_api_docs/index.test.ts
+++ b/src/meta_api_docs/index.test.ts
@@ -4,8 +4,10 @@ import {
   getTopicNames,
   getTopicDescriptions,
   handleMetaApiDocs,
-  metaApiDocsToolDefinition,
+  metaApiDocsToolSpec,
 } from "./index.js";
+
+const metaApiDocsToolDefinition = metaApiDocsToolSpec.definition;
 
 describe("meta_api_docs/index", () => {
   describe("topics", () => {
@@ -127,15 +129,15 @@ describe("meta_api_docs/index", () => {
     });
   });
 
-  describe("metaApiDocsToolDefinition", () => {
+  describe("metaApiDocsToolSpec.definition", () => {
     it("should have required tool properties", () => {
-      expect(metaApiDocsToolDefinition).toHaveProperty("name", "xano_meta_api_docs");
-      expect(metaApiDocsToolDefinition).toHaveProperty("description");
-      expect(metaApiDocsToolDefinition).toHaveProperty("inputSchema");
+      expect(metaApiDocsToolSpec.definition).toHaveProperty("name", "xano_meta_api_docs");
+      expect(metaApiDocsToolSpec.definition).toHaveProperty("description");
+      expect(metaApiDocsToolSpec.definition).toHaveProperty("inputSchema");
     });
 
     it("should have valid inputSchema", () => {
-      const schema = metaApiDocsToolDefinition.inputSchema as {
+      const schema = metaApiDocsToolSpec.definition.inputSchema as unknown as {
         type: string;
         properties: Record<string, unknown>;
         required?: string[];
@@ -148,7 +150,7 @@ describe("meta_api_docs/index", () => {
     });
 
     it("should include all topic names in enum", () => {
-      const schema = metaApiDocsToolDefinition.inputSchema as {
+      const schema = metaApiDocsToolSpec.definition.inputSchema as unknown as {
         properties: { topic: { enum: string[] } };
       };
       expect(schema.properties.topic.enum).toEqual(getTopicNames());

--- a/src/meta_api_docs/index.test.ts
+++ b/src/meta_api_docs/index.test.ts
@@ -129,7 +129,7 @@ describe("meta_api_docs/index", () => {
 
   describe("metaApiDocsToolDefinition", () => {
     it("should have required tool properties", () => {
-      expect(metaApiDocsToolDefinition).toHaveProperty("name", "meta_api_docs");
+      expect(metaApiDocsToolDefinition).toHaveProperty("name", "xano_meta_api_docs");
       expect(metaApiDocsToolDefinition).toHaveProperty("description");
       expect(metaApiDocsToolDefinition).toHaveProperty("inputSchema");
     });

--- a/src/meta_api_docs/index.test.ts
+++ b/src/meta_api_docs/index.test.ts
@@ -135,7 +135,11 @@ describe("meta_api_docs/index", () => {
     });
 
     it("should have valid inputSchema", () => {
-      const schema = metaApiDocsToolDefinition.inputSchema;
+      const schema = metaApiDocsToolDefinition.inputSchema as {
+        type: string;
+        properties: Record<string, unknown>;
+        required?: string[];
+      };
       expect(schema.type).toBe("object");
       expect(schema.properties).toHaveProperty("topic");
       expect(schema.properties).toHaveProperty("detail_level");
@@ -144,8 +148,10 @@ describe("meta_api_docs/index", () => {
     });
 
     it("should include all topic names in enum", () => {
-      const topicEnum = metaApiDocsToolDefinition.inputSchema.properties.topic.enum;
-      expect(topicEnum).toEqual(getTopicNames());
+      const schema = metaApiDocsToolDefinition.inputSchema as {
+        properties: { topic: { enum: string[] } };
+      };
+      expect(schema.properties.topic.enum).toEqual(getTopicNames());
     });
   });
 });

--- a/src/meta_api_docs/index.ts
+++ b/src/meta_api_docs/index.ts
@@ -88,7 +88,7 @@ export function handleMetaApiDocs(args: MetaApiDocsArgs): string {
  * Tool definition for MCP server
  */
 export const metaApiDocsTool_spec = defineTool({
-  name: "meta_api_docs",
+  name: "xano_meta_api_docs",
   description: `Get documentation for Xano's Meta API. Use this to understand how to programmatically manage Xano workspaces, databases, APIs, functions, agents, and more.
 
 ## Topics

--- a/src/meta_api_docs/index.ts
+++ b/src/meta_api_docs/index.ts
@@ -87,7 +87,7 @@ export function handleMetaApiDocs(args: MetaApiDocsArgs): string {
 /**
  * Tool definition for MCP server
  */
-export const metaApiDocsTool_spec = defineTool({
+export const metaApiDocsToolSpec = defineTool({
   name: "xano_meta_api_docs",
   description: `Get documentation for Xano's Meta API. Use this to understand how to programmatically manage Xano workspaces, databases, APIs, functions, agents, and more.
 
@@ -139,4 +139,3 @@ ${getTopicDescriptions()}
   },
 });
 
-export const metaApiDocsToolDefinition = metaApiDocsTool_spec.definition;

--- a/src/meta_api_docs/index.ts
+++ b/src/meta_api_docs/index.ts
@@ -5,8 +5,10 @@
  * the meta_api_docs tool handler for the MCP server.
  */
 
+import { z } from "zod";
 import type { TopicDoc, DetailLevel, MetaApiDocsArgs } from "./types.js";
 import { formatDocumentation } from "./format.js";
+import { defineTool } from "../tools/define_tool.js";
 
 // Import all topic documentation
 import { startDoc } from "./topics/start.js";
@@ -85,14 +87,8 @@ export function handleMetaApiDocs(args: MetaApiDocsArgs): string {
 /**
  * Tool definition for MCP server
  */
-export const metaApiDocsToolDefinition = {
+export const metaApiDocsTool_spec = defineTool({
   name: "meta_api_docs",
-  annotations: {
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
   description: `Get documentation for Xano's Meta API. Use this to understand how to programmatically manage Xano workspaces, databases, APIs, functions, agents, and more.
 
 ## Topics
@@ -102,47 +98,45 @@ ${getTopicDescriptions()}
 - Start with "start" topic for overview and getting started
 - Use "workflows" for step-by-step guides
 - Use specific topics (workspace, table, api, etc.) for detailed endpoint docs`,
-
-  inputSchema: {
-    type: "object",
-    properties: {
-      topic: {
-        type: "string",
-        enum: getTopicNames(),
-        description:
-          "Documentation topic to retrieve. Start with 'start' for an overview of the Meta API. " +
-          "Example: topic='workspace' for workspace management endpoints, topic='table' for database table operations.",
-      },
-      detail_level: {
-        type: "string",
-        enum: ["overview", "detailed", "examples"],
-        default: "detailed",
-        description:
-          "Level of detail to return. " +
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputShape: {
+    topic: z
+      .enum(getTopicNames() as [string, ...string[]])
+      .describe(
+        "Documentation topic to retrieve. Start with 'start' for an overview of the Meta API. " +
+          "Example: topic='workspace' for workspace management endpoints, topic='table' for database table operations."
+      ),
+    detail_level: z
+      .enum(["overview", "detailed", "examples"])
+      .optional()
+      .describe(
+        "Level of detail to return. " +
           "'overview' = brief summary of endpoints and their purpose. " +
           "'detailed' = full API reference with parameters, headers, and response formats. " +
           "'examples' = includes curl and fetch code examples for each endpoint. " +
-          "Default: 'detailed'.",
-      },
-      include_schemas: {
-        type: "boolean",
-        default: true,
-        description:
-          "Include JSON schemas for request bodies and response payloads. " +
+          "Default: 'detailed'."
+      ),
+    include_schemas: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include JSON schemas for request bodies and response payloads. " +
           "Useful for understanding the expected data format. Set to false to reduce response size. " +
-          "Default: true.",
-      },
-    },
-    required: ["topic"],
+          "Default: true."
+      ),
   },
-  outputSchema: {
-    type: "object",
-    properties: {
-      documentation: {
-        type: "string",
-        description: "The Meta API documentation content for the requested topic.",
-      },
-    },
-    required: ["documentation"],
+  outputShape: {
+    documentation: z
+      .string()
+      .describe(
+        "The Meta API documentation content for the requested topic."
+      ),
   },
-};
+});
+
+export const metaApiDocsToolDefinition = metaApiDocsTool_spec.definition;

--- a/src/tools/cli_docs.ts
+++ b/src/tools/cli_docs.ts
@@ -7,8 +7,7 @@
 
 import {
   handleCliDocs as _handleCliDocs,
-  cliDocsToolDefinition,
-  cliDocsTool_spec,
+  cliDocsToolSpec,
   topics,
   getTopicNames,
   getTopicDescriptions,
@@ -21,8 +20,7 @@ import type { ToolResult } from "./types.js";
 // =============================================================================
 
 export {
-  cliDocsToolDefinition,
-  cliDocsTool_spec,
+  cliDocsToolSpec,
   topics as cliTopics,
   getTopicNames as getCliTopicNames,
   getTopicDescriptions as getCliTopicDescriptions,
@@ -96,5 +94,3 @@ export function cliDocsTool(args: CliDocsArgs): ToolResult {
   }
 }
 
-// Re-export tool definition for MCP
-export { cliDocsToolDefinition as toolDefinition };

--- a/src/tools/cli_docs.ts
+++ b/src/tools/cli_docs.ts
@@ -76,7 +76,7 @@ export function cliDocsTool(args: CliDocsArgs): ToolResult {
   if (!args?.topic) {
     return {
       success: false,
-      error: "Error: 'topic' parameter is required. Use cli_docs with topic='start' for overview.",
+      error: "Error: 'topic' parameter is required. Use xano_cli_docs with topic='start' for overview.",
     };
   }
 

--- a/src/tools/cli_docs.ts
+++ b/src/tools/cli_docs.ts
@@ -8,6 +8,7 @@
 import {
   handleCliDocs as _handleCliDocs,
   cliDocsToolDefinition,
+  cliDocsTool_spec,
   topics,
   getTopicNames,
   getTopicDescriptions,
@@ -21,6 +22,7 @@ import type { ToolResult } from "./types.js";
 
 export {
   cliDocsToolDefinition,
+  cliDocsTool_spec,
   topics as cliTopics,
   getTopicNames as getCliTopicNames,
   getTopicDescriptions as getCliTopicDescriptions,

--- a/src/tools/define_tool.test.ts
+++ b/src/tools/define_tool.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { defineTool } from "./define_tool.js";
+
+describe("defineTool", () => {
+  const built = defineTool({
+    name: "test_tool",
+    description: "A test tool",
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    inputShape: {
+      code: z.string().describe("the code"),
+      mode: z.enum(["full", "quick"]).optional().describe("the mode"),
+      tags: z.array(z.string()).optional(),
+      count: z.number().optional(),
+    },
+    outputShape: {
+      ok: z.boolean().describe("success flag"),
+      message: z.string().optional(),
+    },
+  });
+
+  const input = built.definition.inputSchema as unknown as {
+    type: string;
+    properties: Record<string, { type?: string; description?: string; enum?: string[]; items?: { type: string } }>;
+    required?: string[];
+  };
+
+  it("emits an object schema with properties", () => {
+    expect(input.type).toBe("object");
+    expect(input.properties).toHaveProperty("code");
+    expect(input.properties).toHaveProperty("mode");
+  });
+
+  it("preserves .describe() text from Zod shapes", () => {
+    expect(input.properties.code.description).toBe("the code");
+    expect(input.properties.mode.description).toBe("the mode");
+  });
+
+  it("lists only non-optional fields as required", () => {
+    expect(input.required).toEqual(["code"]);
+  });
+
+  it("encodes enums into JSON Schema", () => {
+    expect(input.properties.mode.enum).toEqual(["full", "quick"]);
+  });
+
+  it("encodes z.array(z.string()) as array of strings", () => {
+    expect(input.properties.tags.type).toBe("array");
+    expect(input.properties.tags.items).toEqual({ type: "string" });
+  });
+
+  it("strips $schema dialect key from emitted JSON Schema", () => {
+    expect(input).not.toHaveProperty("$schema");
+    expect(built.definition.outputSchema).not.toHaveProperty("$schema");
+  });
+
+  it("strips additionalProperties so wire schema stays permissive", () => {
+    expect(input).not.toHaveProperty("additionalProperties");
+    expect(built.definition.outputSchema).not.toHaveProperty(
+      "additionalProperties"
+    );
+  });
+
+  it("inputParser accepts what the schema declares as valid", () => {
+    const parsed = built.inputParser.safeParse({ code: "x", mode: "full" });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("inputParser rejects invalid enum values", () => {
+    const parsed = built.inputParser.safeParse({ code: "x", mode: "nope" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("inputParser strips unknown keys (forward-compat with wire schema)", () => {
+    const parsed = built.inputParser.safeParse({ code: "x", extra: 42 });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).not.toHaveProperty("extra");
+    }
+  });
+});

--- a/src/tools/define_tool.ts
+++ b/src/tools/define_tool.ts
@@ -1,0 +1,62 @@
+/**
+ * Tool definition helper.
+ *
+ * Single source of truth: Zod input/output shapes carry parameter descriptions,
+ * enums, and validation rules. JSON Schema for the MCP protocol is derived
+ * from those shapes via `z.toJSONSchema`, so the wire-level schema and the
+ * runtime parser can never drift.
+ */
+
+import { z } from "zod";
+
+export type ZodRawShape = Record<string, z.ZodTypeAny>;
+
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  annotations: ToolAnnotations;
+  inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+}
+
+export interface ToolSpec<I extends ZodRawShape, O extends ZodRawShape> {
+  name: string;
+  description: string;
+  annotations: ToolAnnotations;
+  inputShape: I;
+  outputShape: O;
+}
+
+export interface BuiltTool<I extends ZodRawShape, O extends ZodRawShape>
+  extends ToolSpec<I, O> {
+  definition: ToolDefinition;
+  inputParser: z.ZodObject<I>;
+}
+
+/**
+ * Build a tool from Zod shapes. Returns the spec plus a derived JSON Schema
+ * `definition` (for library consumers) and an `inputParser` (for safe parsing).
+ */
+export function defineTool<I extends ZodRawShape, O extends ZodRawShape>(
+  spec: ToolSpec<I, O>
+): BuiltTool<I, O> {
+  const inputParser = z.object(spec.inputShape);
+  const outputObj = z.object(spec.outputShape);
+
+  const definition: ToolDefinition = {
+    name: spec.name,
+    description: spec.description,
+    annotations: spec.annotations,
+    inputSchema: z.toJSONSchema(inputParser) as Record<string, unknown>,
+    outputSchema: z.toJSONSchema(outputObj) as Record<string, unknown>,
+  };
+
+  return { ...spec, definition, inputParser };
+}

--- a/src/tools/define_tool.ts
+++ b/src/tools/define_tool.ts
@@ -12,18 +12,27 @@ import { z } from "zod";
 export type ZodRawShape = Record<string, z.ZodTypeAny>;
 
 export interface ToolAnnotations {
-  readOnlyHint?: boolean;
-  destructiveHint?: boolean;
-  idempotentHint?: boolean;
-  openWorldHint?: boolean;
+  readonly readOnlyHint?: boolean;
+  readonly destructiveHint?: boolean;
+  readonly idempotentHint?: boolean;
+  readonly openWorldHint?: boolean;
 }
 
+/**
+ * Branded JSON Schema type. Anything emitted by `defineTool` is guaranteed
+ * to have passed through `z.toJSONSchema` and had wire-incompatible keys
+ * (`$schema`, `additionalProperties`) stripped.
+ */
+export type JsonSchema = Readonly<Record<string, unknown>> & {
+  readonly __jsonSchemaBrand: unique symbol;
+};
+
 export interface ToolDefinition {
-  name: string;
-  description: string;
-  annotations: ToolAnnotations;
-  inputSchema: Record<string, unknown>;
-  outputSchema: Record<string, unknown>;
+  readonly name: string;
+  readonly description: string;
+  readonly annotations: ToolAnnotations;
+  readonly inputSchema: JsonSchema;
+  readonly outputSchema: JsonSchema;
 }
 
 export interface ToolSpec<I extends ZodRawShape, O extends ZodRawShape> {
@@ -36,8 +45,20 @@ export interface ToolSpec<I extends ZodRawShape, O extends ZodRawShape> {
 
 export interface BuiltTool<I extends ZodRawShape, O extends ZodRawShape>
   extends ToolSpec<I, O> {
-  definition: ToolDefinition;
-  inputParser: z.ZodObject<I>;
+  readonly definition: ToolDefinition;
+  readonly inputParser: z.ZodObject<I>;
+}
+
+/**
+ * Strip keys that MCP clients/SDKs don't expect on tool schemas.
+ * - `$schema`: dialect URL added by zod 4 — not part of the MCP wire format.
+ * - `additionalProperties: false`: emitted by zod for `z.object`; we want
+ *   the wire schema to remain forward-compatible (extra keys ignored by the
+ *   parser anyway since `z.object` strips them).
+ */
+function sanitizeJsonSchema(schema: Record<string, unknown>): JsonSchema {
+  const { $schema: _$schema, additionalProperties: _ap, ...rest } = schema;
+  return rest as JsonSchema;
 }
 
 /**
@@ -54,8 +75,12 @@ export function defineTool<I extends ZodRawShape, O extends ZodRawShape>(
     name: spec.name,
     description: spec.description,
     annotations: spec.annotations,
-    inputSchema: z.toJSONSchema(inputParser) as Record<string, unknown>,
-    outputSchema: z.toJSONSchema(outputObj) as Record<string, unknown>,
+    inputSchema: sanitizeJsonSchema(
+      z.toJSONSchema(inputParser) as Record<string, unknown>
+    ),
+    outputSchema: sanitizeJsonSchema(
+      z.toJSONSchema(outputObj) as Record<string, unknown>
+    ),
   };
 
   return { ...spec, definition, inputParser };

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -19,21 +19,21 @@ beforeAll(() => {
 });
 
 describe("handleTool", () => {
-  it("should handle xanoscript_docs tool", () => {
-    const result = handleTool("xanoscript_docs", {});
+  it("should handle xanoscript_docs tool", async () => {
+    const result = await handleTool("xanoscript_docs", {});
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
-  it("should handle xanoscript_docs with topic arg", () => {
-    const result = handleTool("xanoscript_docs", { topic: "syntax" });
+  it("should handle xanoscript_docs with topic arg", async () => {
+    const result = await handleTool("xanoscript_docs", { topic: "syntax" });
     expect(result.success).toBe(true);
     expect(typeof result.data).toBe("string");
     expect(result.data).toContain("Documentation version:");
   });
 
-  it("should handle xanoscript_docs with file_path and return multi-content", () => {
-    const result = handleTool("xanoscript_docs", { file_path: "api/users/create.xs" });
+  it("should handle xanoscript_docs with file_path and return multi-content", async () => {
+    const result = await handleTool("xanoscript_docs", { file_path: "api/users/create.xs" });
     expect(result.success).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
     const data = result.data as string[];
@@ -41,77 +41,82 @@ describe("handleTool", () => {
     expect(data[0]).toContain("Matched topics:");
   });
 
-  it("should handle validate_xanoscript tool and return a ToolResult", () => {
-    const result = handleTool("validate_xanoscript", { code: "var $x:int = 1" });
+  it("should handle xanoscript_docs with tier (regression: was silently dropped)", async () => {
+    const result = await handleTool("xanoscript_docs", { tier: "survival" });
+    expect(result.success).toBe(true);
+    expect(result.structuredContent).toMatchObject({ tier: "survival" });
+  });
+
+  it("should handle validate_xanoscript tool and return a ToolResult", async () => {
+    const result = await handleTool("validate_xanoscript", { code: "var $x:int = 1" });
     expect(result).toHaveProperty("success");
     expect(typeof result.success).toBe("boolean");
-    // Either data or error should be present
     expect(result.data ?? result.error).toBeDefined();
   });
 
-  it("should handle validate_xanoscript with missing input", () => {
-    const result = handleTool("validate_xanoscript", {});
+  it("should handle validate_xanoscript with missing input", async () => {
+    const result = await handleTool("validate_xanoscript", {});
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
   });
 
-  it("should handle mcp_version tool", () => {
-    const result = handleTool("mcp_version", {});
+  it("should handle mcp_version tool", async () => {
+    const result = await handleTool("mcp_version", {});
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
-  it("should handle meta_api_docs tool with topic", () => {
-    const result = handleTool("meta_api_docs", { topic: "start" });
+  it("should handle meta_api_docs tool with topic", async () => {
+    const result = await handleTool("meta_api_docs", { topic: "start" });
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
-  it("should handle meta_api_docs tool without topic", () => {
-    const result = handleTool("meta_api_docs", {});
+  it("should handle meta_api_docs tool without topic", async () => {
+    const result = await handleTool("meta_api_docs", {});
     expect(result.success).toBe(false);
-    expect(result.error).toContain("topic");
+    expect(result.error).toBeDefined();
   });
 
-  it("should handle cli_docs tool with topic", () => {
-    const result = handleTool("cli_docs", { topic: "start" });
+  it("should handle cli_docs tool with topic", async () => {
+    const result = await handleTool("cli_docs", { topic: "start" });
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
-  it("should handle cli_docs tool without topic", () => {
-    const result = handleTool("cli_docs", {});
+  it("should handle cli_docs tool without topic", async () => {
+    const result = await handleTool("cli_docs", {});
     expect(result.success).toBe(false);
-    expect(result.error).toContain("topic");
+    expect(result.error).toBeDefined();
   });
 
-  it("should return error for unknown tool", () => {
-    const result = handleTool("nonexistent_tool", {});
+  it("should return error for unknown tool", async () => {
+    const result = await handleTool("nonexistent_tool", {});
     expect(result.success).toBe(false);
     expect(result.error).toContain("Unknown tool: nonexistent_tool");
   });
 
-  it("should return validation error for wrong argument types", () => {
-    const result = handleTool("xanoscript_docs", { mode: 123 });
+  it("should return validation error for wrong argument types", async () => {
+    const result = await handleTool("xanoscript_docs", { mode: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
 
-  it("should return validation error for invalid enum value", () => {
-    const result = handleTool("xanoscript_docs", { mode: "invalid_mode" });
+  it("should return validation error for invalid enum value", async () => {
+    const result = await handleTool("xanoscript_docs", { mode: "invalid_mode" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
 
-  it("should return validation error when meta_api_docs topic is wrong type", () => {
-    const result = handleTool("meta_api_docs", { topic: 123 });
+  it("should return validation error when meta_api_docs topic is wrong type", async () => {
+    const result = await handleTool("meta_api_docs", { topic: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
 });
 
 describe("toMcpResponse", () => {
-  it("should convert success result to MCP response", () => {
+  it("should convert success result to MCP response", async () => {
     const response = toMcpResponse({ success: true, data: "test data" });
     expect(response.content).toHaveLength(1);
     expect(response.content[0].type).toBe("text");
@@ -119,14 +124,14 @@ describe("toMcpResponse", () => {
     expect(response.isError).toBeUndefined();
   });
 
-  it("should convert error result to MCP response with isError", () => {
+  it("should convert error result to MCP response with isError", async () => {
     const response = toMcpResponse({ success: false, error: "test error" });
     expect(response.content).toHaveLength(1);
     expect(response.content[0].text).toBe("test error");
     expect(response.isError).toBe(true);
   });
 
-  it("should convert string array data to multiple content blocks", () => {
+  it("should convert string array data to multiple content blocks", async () => {
     const response = toMcpResponse({
       success: true,
       data: ["block one", "block two", "block three"],
@@ -138,13 +143,13 @@ describe("toMcpResponse", () => {
     expect(response.isError).toBeUndefined();
   });
 
-  it("should handle single-element array data", () => {
+  it("should handle single-element array data", async () => {
     const response = toMcpResponse({ success: true, data: ["only block"] });
     expect(response.content).toHaveLength(1);
     expect(response.content[0].text).toBe("only block");
   });
 
-  it("should include structuredContent when provided", () => {
+  it("should include structuredContent when provided", async () => {
     const response = toMcpResponse({
       success: true,
       data: "test",
@@ -154,12 +159,12 @@ describe("toMcpResponse", () => {
     expect(response.isError).toBeUndefined();
   });
 
-  it("should omit structuredContent when not provided", () => {
+  it("should omit structuredContent when not provided", async () => {
     const response = toMcpResponse({ success: true, data: "test" });
     expect(response.structuredContent).toBeUndefined();
   });
 
-  it("should not include structuredContent on error", () => {
+  it("should not include structuredContent on error", async () => {
     const response = toMcpResponse({ success: false, error: "fail" });
     expect(response.structuredContent).toBeUndefined();
     expect(response.isError).toBe(true);
@@ -167,16 +172,16 @@ describe("toMcpResponse", () => {
 });
 
 describe("toolDefinitions", () => {
-  it("should contain all 5 tools", () => {
+  it("should contain all 5 tools", async () => {
     expect(toolDefinitions).toHaveLength(5);
   });
 
-  it("should have unique tool names", () => {
+  it("should have unique tool names", async () => {
     const names = toolDefinitions.map((t) => t.name);
     expect(new Set(names).size).toBe(names.length);
   });
 
-  it("should include expected tool names", () => {
+  it("should include expected tool names", async () => {
     const names = toolDefinitions.map((t) => t.name);
     expect(names).toContain("validate_xanoscript");
     expect(names).toContain("xanoscript_docs");
@@ -185,7 +190,7 @@ describe("toolDefinitions", () => {
     expect(names).toContain("cli_docs");
   });
 
-  it("should have annotations on all tools", () => {
+  it("should have annotations on all tools", async () => {
     for (const tool of toolDefinitions) {
       expect(tool).toHaveProperty("annotations");
       expect(tool.annotations).toHaveProperty("readOnlyHint");
@@ -193,11 +198,11 @@ describe("toolDefinitions", () => {
     }
   });
 
-  it("should have outputSchema on all tools", () => {
+  it("should have outputSchema on all tools", async () => {
     for (const tool of toolDefinitions) {
       expect(tool).toHaveProperty("outputSchema");
-      expect((tool as Record<string, unknown>).outputSchema).toHaveProperty("type", "object");
-      expect((tool as Record<string, unknown>).outputSchema).toHaveProperty("properties");
+      expect(tool.outputSchema).toHaveProperty("type", "object");
+      expect(tool.outputSchema).toHaveProperty("properties");
     }
   });
 });

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -20,20 +20,20 @@ beforeAll(() => {
 
 describe("handleTool", () => {
   it("should handle xanoscript_docs tool", async () => {
-    const result = await handleTool("xanoscript_docs", {});
+    const result = await handleTool("xano_xanoscript_docs", {});
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
   it("should handle xanoscript_docs with topic arg", async () => {
-    const result = await handleTool("xanoscript_docs", { topic: "syntax" });
+    const result = await handleTool("xano_xanoscript_docs", { topic: "syntax" });
     expect(result.success).toBe(true);
     expect(typeof result.data).toBe("string");
     expect(result.data).toContain("Documentation version:");
   });
 
   it("should handle xanoscript_docs with file_path and return multi-content", async () => {
-    const result = await handleTool("xanoscript_docs", { file_path: "api/users/create.xs" });
+    const result = await handleTool("xano_xanoscript_docs", { file_path: "api/users/create.xs" });
     expect(result.success).toBe(true);
     expect(Array.isArray(result.data)).toBe(true);
     const data = result.data as string[];
@@ -42,50 +42,50 @@ describe("handleTool", () => {
   });
 
   it("should handle xanoscript_docs with tier (regression: was silently dropped)", async () => {
-    const result = await handleTool("xanoscript_docs", { tier: "survival" });
+    const result = await handleTool("xano_xanoscript_docs", { tier: "survival" });
     expect(result.success).toBe(true);
     expect(result.structuredContent).toMatchObject({ tier: "survival" });
   });
 
   it("should handle validate_xanoscript tool and return a ToolResult", async () => {
-    const result = await handleTool("validate_xanoscript", { code: "var $x:int = 1" });
+    const result = await handleTool("xano_validate_xanoscript", { code: "var $x:int = 1" });
     expect(result).toHaveProperty("success");
     expect(typeof result.success).toBe("boolean");
     expect(result.data ?? result.error).toBeDefined();
   });
 
   it("should handle validate_xanoscript with missing input", async () => {
-    const result = await handleTool("validate_xanoscript", {});
+    const result = await handleTool("xano_validate_xanoscript", {});
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
   });
 
   it("should handle mcp_version tool", async () => {
-    const result = await handleTool("mcp_version", {});
+    const result = await handleTool("xano_version", {});
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
   it("should handle meta_api_docs tool with topic", async () => {
-    const result = await handleTool("meta_api_docs", { topic: "start" });
+    const result = await handleTool("xano_meta_api_docs", { topic: "start" });
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
   it("should handle meta_api_docs tool without topic", async () => {
-    const result = await handleTool("meta_api_docs", {});
+    const result = await handleTool("xano_meta_api_docs", {});
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
   });
 
   it("should handle cli_docs tool with topic", async () => {
-    const result = await handleTool("cli_docs", { topic: "start" });
+    const result = await handleTool("xano_cli_docs", { topic: "start" });
     expect(result.success).toBe(true);
     expect(result.data).toBeDefined();
   });
 
   it("should handle cli_docs tool without topic", async () => {
-    const result = await handleTool("cli_docs", {});
+    const result = await handleTool("xano_cli_docs", {});
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
   });
@@ -97,19 +97,19 @@ describe("handleTool", () => {
   });
 
   it("should return validation error for wrong argument types", async () => {
-    const result = await handleTool("xanoscript_docs", { mode: 123 });
+    const result = await handleTool("xano_xanoscript_docs", { mode: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
 
   it("should return validation error for invalid enum value", async () => {
-    const result = await handleTool("xanoscript_docs", { mode: "invalid_mode" });
+    const result = await handleTool("xano_xanoscript_docs", { mode: "invalid_mode" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
 
   it("should return validation error when meta_api_docs topic is wrong type", async () => {
-    const result = await handleTool("meta_api_docs", { topic: 123 });
+    const result = await handleTool("xano_meta_api_docs", { topic: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
   });
@@ -183,11 +183,11 @@ describe("toolDefinitions", () => {
 
   it("should include expected tool names", async () => {
     const names = toolDefinitions.map((t) => t.name);
-    expect(names).toContain("validate_xanoscript");
-    expect(names).toContain("xanoscript_docs");
-    expect(names).toContain("mcp_version");
-    expect(names).toContain("meta_api_docs");
-    expect(names).toContain("cli_docs");
+    expect(names).toContain("xano_validate_xanoscript");
+    expect(names).toContain("xano_xanoscript_docs");
+    expect(names).toContain("xano_version");
+    expect(names).toContain("xano_meta_api_docs");
+    expect(names).toContain("xano_cli_docs");
   });
 
   it("should have annotations on all tools", async () => {

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -100,18 +100,41 @@ describe("handleTool", () => {
     const result = await handleTool("xano_xanoscript_docs", { mode: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
+    // Field name should appear so users can see what's wrong
+    expect(result.error).toContain("mode");
   });
 
   it("should return validation error for invalid enum value", async () => {
     const result = await handleTool("xano_xanoscript_docs", { mode: "invalid_mode" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
+    expect(result.error).toContain("mode");
   });
 
   it("should return validation error when meta_api_docs topic is wrong type", async () => {
     const result = await handleTool("xano_meta_api_docs", { topic: 123 });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid arguments");
+    expect(result.error).toContain("topic");
+  });
+});
+
+describe("validate_xanoscript warnings count", () => {
+  it("structuredContent.warnings is included on success", async () => {
+    // We don't bake a specific snippet's warning count into the test — the
+    // language server's warning rules change. The contract we *do* care about
+    // is that `warnings` is present on a successful validation result and is
+    // a number >= 0.
+    const result = await handleTool("xano_validate_xanoscript", {
+      code: "return 1",
+    });
+    if (result.success) {
+      expect(result.structuredContent).toBeDefined();
+      const sc = result.structuredContent as { warnings?: number; valid?: boolean };
+      expect(sc.valid).toBe(true);
+      expect(typeof sc.warnings).toBe("number");
+      expect(sc.warnings).toBeGreaterThanOrEqual(0);
+    }
   });
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,6 +37,7 @@ import {
   validateXanoscript,
   validateXanoscriptTool,
   validateXanoscriptToolDefinition,
+  validateXanoscriptTool_spec,
   TYPE_ALIASES,
   RESERVED_VARIABLES,
   type ValidateXanoscriptArgs,
@@ -50,6 +51,7 @@ import {
   xanoscriptDocs,
   xanoscriptDocsTool,
   xanoscriptDocsToolDefinition,
+  xanoscriptDocsTool_spec,
   getXanoscriptDocsPath,
   setXanoscriptDocsPath,
   type XanoscriptDocsArgs,
@@ -61,6 +63,7 @@ import {
   mcpVersion,
   mcpVersionTool,
   mcpVersionToolDefinition,
+  mcpVersionTool_spec,
   getServerVersion,
   setServerVersion,
   type McpVersionResult,
@@ -70,6 +73,7 @@ import {
   metaApiDocs,
   metaApiDocsTool,
   metaApiDocsToolDefinition,
+  metaApiDocsTool_spec,
   metaApiTopics,
   getMetaApiTopicNames,
   getMetaApiTopicDescriptions,
@@ -81,6 +85,7 @@ import {
   cliDocs,
   cliDocsTool,
   cliDocsToolDefinition,
+  cliDocsTool_spec,
   cliTopics,
   getCliTopicNames,
   getCliTopicDescriptions,
@@ -90,6 +95,7 @@ import {
 
 import { type ToolResult, toMcpResponse } from "./types.js";
 import { z } from "zod";
+import type { BuiltTool, ZodRawShape } from "./define_tool.js";
 
 // =============================================================================
 // Standalone Tool Functions (for library usage)
@@ -176,88 +182,74 @@ export const toolDefinitions = [
   cliDocsToolDefinition,
 ];
 
+/**
+ * Full tool specs (Zod shapes + derived JSON Schema). Use these to register
+ * tools with `McpServer.registerTool` — descriptions live in the shapes and
+ * the JSON Schema can never drift from the parser.
+ */
+export const toolSpecs = {
+  validate_xanoscript: validateXanoscriptTool_spec,
+  xanoscript_docs: xanoscriptDocsTool_spec,
+  mcp_version: mcpVersionTool_spec,
+  meta_api_docs: metaApiDocsTool_spec,
+  cli_docs: cliDocsTool_spec,
+} as const;
+
 // =============================================================================
-// Argument Schemas (Zod validation)
+// Tool Handler (for MCP server / library)
 // =============================================================================
 
-const validateXanoscriptSchema = z.object({
-  code: z.string().optional(),
-  file_path: z.string().optional(),
-  file_paths: z.array(z.string()).optional(),
-  directory: z.string().optional(),
-  pattern: z.string().optional(),
-});
-
-const xanoscriptDocsSchema = z.object({
-  topic: z.string().optional(),
-  file_path: z.string().optional(),
-  mode: z.enum(["full", "quick_reference", "index"]).optional(),
-  exclude_topics: z.array(z.string()).optional(),
-});
-
-const metaApiDocsSchema = z.object({
-  topic: z.string(),
-  detail_level: z.enum(["overview", "detailed", "examples"]).optional(),
-  include_schemas: z.boolean().optional(),
-});
-
-const cliDocsSchema = z.object({
-  topic: z.string(),
-  detail_level: z.enum(["overview", "detailed", "examples"]).optional(),
-});
-
-function parseArgs<T>(
-  schema: z.ZodType<T>,
+function parseWithSpec<I extends ZodRawShape, O extends ZodRawShape>(
+  spec: BuiltTool<I, O>,
   args: Record<string, unknown>
-): { ok: true; data: T } | { ok: false; error: ToolResult } {
-  const result = schema.safeParse(args);
+): { ok: true; data: z.infer<z.ZodObject<I>> } | { ok: false; error: ToolResult } {
+  const result = spec.inputParser.safeParse(args);
   if (!result.success) {
     const issues = result.error.issues
       .map((i) => `${i.path.join(".")}: ${i.message}`)
       .join("; ");
-    return { ok: false, error: { success: false, error: `Invalid arguments: ${issues}` } };
+    return {
+      ok: false,
+      error: { success: false, error: `Invalid arguments: ${issues}` },
+    };
   }
-  return { ok: true, data: result.data };
+  return { ok: true, data: result.data as z.infer<z.ZodObject<I>> };
 }
-
-// =============================================================================
-// Tool Handler (for MCP server)
-// =============================================================================
 
 /**
  * Handle a tool call by name and return the result.
- * This is used by the MCP server to dispatch tool calls.
+ * Async to allow future tools that perform I/O without breaking the signature.
  */
-export function handleTool(
+export async function handleTool(
   name: string,
   args: Record<string, unknown>
-): ToolResult {
+): Promise<ToolResult> {
   switch (name) {
     case "validate_xanoscript": {
-      const parsed = parseArgs(validateXanoscriptSchema, args);
+      const parsed = parseWithSpec(validateXanoscriptTool_spec, args);
       if (!parsed.ok) return parsed.error;
-      return validateXanoscriptTool(parsed.data);
+      return validateXanoscriptTool(parsed.data as ValidateXanoscriptArgs);
     }
 
     case "xanoscript_docs": {
-      const parsed = parseArgs(xanoscriptDocsSchema, args);
+      const parsed = parseWithSpec(xanoscriptDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
-      return xanoscriptDocsTool(parsed.data);
+      return xanoscriptDocsTool(parsed.data as XanoscriptDocsArgs);
     }
 
     case "mcp_version":
       return mcpVersionTool();
 
     case "meta_api_docs": {
-      const parsed = parseArgs(metaApiDocsSchema, args);
+      const parsed = parseWithSpec(metaApiDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
-      return metaApiDocsTool(parsed.data);
+      return metaApiDocsTool(parsed.data as MetaApiDocsArgs);
     }
 
     case "cli_docs": {
-      const parsed = parseArgs(cliDocsSchema, args);
+      const parsed = parseWithSpec(cliDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
-      return cliDocsTool(parsed.data);
+      return cliDocsTool(parsed.data as CliDocsArgs);
     }
 
     default:

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,43 +1,17 @@
 /**
  * Xano Developer MCP Tools
  *
- * This module exports all tools for both MCP server usage and standalone library usage.
- *
- * @example MCP Server Usage (internal)
- * ```ts
- * import { toolDefinitions, handleTool } from './tools/index.js';
- *
- * // Register tools with MCP server
- * server.setRequestHandler(ListToolsRequestSchema, () => ({
- *   tools: toolDefinitions
- * }));
- * ```
- *
- * @example Library Usage (external)
- * ```ts
- * import {
- *   validateXanoscript,
- *   xanoscriptDocs,
- *   metaApiDocs,
- *   cliDocs,
- *   mcpVersion
- * } from '@xano/developer-mcp';
- *
- * // Use tools directly
- * const result = validateXanoscript({ code: 'return 1 + 1' });
- * const docs = xanoscriptDocs({ topic: 'syntax' });
- * ```
+ * Exports all tools for both MCP server usage and standalone library usage.
+ * Tool registration goes through `toolSpecs` and `handleTool` below — the
+ * `toolSpecs` map is the single source of truth for which tools exist and
+ * the dispatch table in `handleTool` is statically required to cover every
+ * key, so a new tool cannot be registered without being routed.
  */
-
-// =============================================================================
-// Tool Imports
-// =============================================================================
 
 import {
   validateXanoscript,
   validateXanoscriptTool,
-  validateXanoscriptToolDefinition,
-  validateXanoscriptTool_spec,
+  validateXanoscriptToolSpec,
   TYPE_ALIASES,
   RESERVED_VARIABLES,
   type ValidateXanoscriptArgs,
@@ -50,8 +24,7 @@ import {
 import {
   xanoscriptDocs,
   xanoscriptDocsTool,
-  xanoscriptDocsToolDefinition,
-  xanoscriptDocsTool_spec,
+  xanoscriptDocsToolSpec,
   getXanoscriptDocsPath,
   setXanoscriptDocsPath,
   type XanoscriptDocsArgs,
@@ -62,8 +35,7 @@ import {
 import {
   mcpVersion,
   mcpVersionTool,
-  mcpVersionToolDefinition,
-  mcpVersionTool_spec,
+  mcpVersionToolSpec,
   getServerVersion,
   setServerVersion,
   type McpVersionResult,
@@ -72,8 +44,7 @@ import {
 import {
   metaApiDocs,
   metaApiDocsTool,
-  metaApiDocsToolDefinition,
-  metaApiDocsTool_spec,
+  metaApiDocsToolSpec,
   metaApiTopics,
   getMetaApiTopicNames,
   getMetaApiTopicDescriptions,
@@ -84,8 +55,7 @@ import {
 import {
   cliDocs,
   cliDocsTool,
-  cliDocsToolDefinition,
-  cliDocsTool_spec,
+  cliDocsToolSpec,
   cliTopics,
   getCliTopicNames,
   getCliTopicDescriptions,
@@ -160,27 +130,8 @@ export {
 };
 
 // =============================================================================
-// MCP Tool Definitions
+// Tool Registry — single source of truth
 // =============================================================================
-
-export {
-  validateXanoscriptToolDefinition,
-  xanoscriptDocsToolDefinition,
-  mcpVersionToolDefinition,
-  metaApiDocsToolDefinition,
-  cliDocsToolDefinition,
-};
-
-/**
- * All tool definitions for MCP server registration
- */
-export const toolDefinitions = [
-  validateXanoscriptToolDefinition,
-  xanoscriptDocsToolDefinition,
-  mcpVersionToolDefinition,
-  metaApiDocsToolDefinition,
-  cliDocsToolDefinition,
-];
 
 /**
  * Full tool specs (Zod shapes + derived JSON Schema). Use these to register
@@ -188,15 +139,26 @@ export const toolDefinitions = [
  * the JSON Schema can never drift from the parser.
  */
 export const toolSpecs = {
-  xano_validate_xanoscript: validateXanoscriptTool_spec,
-  xano_xanoscript_docs: xanoscriptDocsTool_spec,
-  xano_version: mcpVersionTool_spec,
-  xano_meta_api_docs: metaApiDocsTool_spec,
-  xano_cli_docs: cliDocsTool_spec,
+  xano_validate_xanoscript: validateXanoscriptToolSpec,
+  xano_xanoscript_docs: xanoscriptDocsToolSpec,
+  xano_version: mcpVersionToolSpec,
+  xano_meta_api_docs: metaApiDocsToolSpec,
+  xano_cli_docs: cliDocsToolSpec,
 } as const;
 
+export type ToolName = keyof typeof toolSpecs;
+
+/**
+ * Tool definitions array (derived from toolSpecs). Kept for callers that
+ * want a flat list to advertise.
+ */
+export const toolDefinitions = Object.values(toolSpecs).map(
+  (spec) => spec.definition
+);
+
 // =============================================================================
-// Tool Handler (for MCP server / library)
+// Tool Handler (typed dispatch — adding to toolSpecs without adding here is
+// a compile error)
 // =============================================================================
 
 function parseWithSpec<I extends ZodRawShape, O extends ZodRawShape>(
@@ -206,7 +168,10 @@ function parseWithSpec<I extends ZodRawShape, O extends ZodRawShape>(
   const result = spec.inputParser.safeParse(args);
   if (!result.success) {
     const issues = result.error.issues
-      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .map((i) => {
+        const path = i.path.join(".") || "(root)";
+        return `${path} [${i.code}]: ${i.message}`;
+      })
       .join("; ");
     return {
       ok: false,
@@ -217,6 +182,41 @@ function parseWithSpec<I extends ZodRawShape, O extends ZodRawShape>(
 }
 
 /**
+ * Dispatch table — every key in `toolSpecs` must have a handler here, or
+ * TypeScript will fail to compile. Adding a tool means: add to `toolSpecs`,
+ * then add a handler entry below.
+ */
+const dispatch: { [K in ToolName]: (args: Record<string, unknown>) => Promise<ToolResult> } = {
+  async xano_validate_xanoscript(args) {
+    const parsed = parseWithSpec(validateXanoscriptToolSpec, args);
+    if (!parsed.ok) return parsed.error;
+    return validateXanoscriptTool(parsed.data as ValidateXanoscriptArgs);
+  },
+  async xano_xanoscript_docs(args) {
+    const parsed = parseWithSpec(xanoscriptDocsToolSpec, args);
+    if (!parsed.ok) return parsed.error;
+    return xanoscriptDocsTool(parsed.data as XanoscriptDocsArgs);
+  },
+  async xano_version() {
+    return mcpVersionTool();
+  },
+  async xano_meta_api_docs(args) {
+    const parsed = parseWithSpec(metaApiDocsToolSpec, args);
+    if (!parsed.ok) return parsed.error;
+    return metaApiDocsTool(parsed.data as MetaApiDocsArgs);
+  },
+  async xano_cli_docs(args) {
+    const parsed = parseWithSpec(cliDocsToolSpec, args);
+    if (!parsed.ok) return parsed.error;
+    return cliDocsTool(parsed.data as CliDocsArgs);
+  },
+};
+
+function isToolName(name: string): name is ToolName {
+  return name in dispatch;
+}
+
+/**
  * Handle a tool call by name and return the result.
  * Async to allow future tools that perform I/O without breaking the signature.
  */
@@ -224,38 +224,8 @@ export async function handleTool(
   name: string,
   args: Record<string, unknown>
 ): Promise<ToolResult> {
-  switch (name) {
-    case "xano_validate_xanoscript": {
-      const parsed = parseWithSpec(validateXanoscriptTool_spec, args);
-      if (!parsed.ok) return parsed.error;
-      return validateXanoscriptTool(parsed.data as ValidateXanoscriptArgs);
-    }
-
-    case "xano_xanoscript_docs": {
-      const parsed = parseWithSpec(xanoscriptDocsTool_spec, args);
-      if (!parsed.ok) return parsed.error;
-      return xanoscriptDocsTool(parsed.data as XanoscriptDocsArgs);
-    }
-
-    case "xano_version":
-      return mcpVersionTool();
-
-    case "xano_meta_api_docs": {
-      const parsed = parseWithSpec(metaApiDocsTool_spec, args);
-      if (!parsed.ok) return parsed.error;
-      return metaApiDocsTool(parsed.data as MetaApiDocsArgs);
-    }
-
-    case "xano_cli_docs": {
-      const parsed = parseWithSpec(cliDocsTool_spec, args);
-      if (!parsed.ok) return parsed.error;
-      return cliDocsTool(parsed.data as CliDocsArgs);
-    }
-
-    default:
-      return {
-        success: false,
-        error: `Unknown tool: ${name}`,
-      };
+  if (!isToolName(name)) {
+    return { success: false, error: `Unknown tool: ${name}` };
   }
+  return dispatch[name](args);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -188,11 +188,11 @@ export const toolDefinitions = [
  * the JSON Schema can never drift from the parser.
  */
 export const toolSpecs = {
-  validate_xanoscript: validateXanoscriptTool_spec,
-  xanoscript_docs: xanoscriptDocsTool_spec,
-  mcp_version: mcpVersionTool_spec,
-  meta_api_docs: metaApiDocsTool_spec,
-  cli_docs: cliDocsTool_spec,
+  xano_validate_xanoscript: validateXanoscriptTool_spec,
+  xano_xanoscript_docs: xanoscriptDocsTool_spec,
+  xano_version: mcpVersionTool_spec,
+  xano_meta_api_docs: metaApiDocsTool_spec,
+  xano_cli_docs: cliDocsTool_spec,
 } as const;
 
 // =============================================================================
@@ -225,28 +225,28 @@ export async function handleTool(
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   switch (name) {
-    case "validate_xanoscript": {
+    case "xano_validate_xanoscript": {
       const parsed = parseWithSpec(validateXanoscriptTool_spec, args);
       if (!parsed.ok) return parsed.error;
       return validateXanoscriptTool(parsed.data as ValidateXanoscriptArgs);
     }
 
-    case "xanoscript_docs": {
+    case "xano_xanoscript_docs": {
       const parsed = parseWithSpec(xanoscriptDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
       return xanoscriptDocsTool(parsed.data as XanoscriptDocsArgs);
     }
 
-    case "mcp_version":
+    case "xano_version":
       return mcpVersionTool();
 
-    case "meta_api_docs": {
+    case "xano_meta_api_docs": {
       const parsed = parseWithSpec(metaApiDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
       return metaApiDocsTool(parsed.data as MetaApiDocsArgs);
     }
 
-    case "cli_docs": {
+    case "xano_cli_docs": {
       const parsed = parseWithSpec(cliDocsTool_spec, args);
       if (!parsed.ok) return parsed.error;
       return cliDocsTool(parsed.data as CliDocsArgs);

--- a/src/tools/mcp_server.test.ts
+++ b/src/tools/mcp_server.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { toolSpecs, handleTool, toMcpResponse } from "./index.js";
+import { setXanoscriptDocsPath } from "./xanoscript_docs.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DOCS_PATH = join(__dirname, "..", "xanoscript_docs");
+
+beforeAll(() => {
+  setXanoscriptDocsPath(DOCS_PATH);
+});
+
+/**
+ * Smoke test: register every tool with `McpServer.registerTool` (the real
+ * registration path from src/index.ts) and verify a `Client.listTools()`
+ * round-trip surfaces each tool with its derived schema. Catches:
+ *  - registerTool throwing on a malformed inputShape/outputShape
+ *  - SDK rejecting a JSON schema we emit
+ *  - tool names drifting between toolSpecs and what's advertised
+ */
+async function buildLinkedClient() {
+  const server = new McpServer({
+    name: "xano-developer-mcp-test",
+    version: "0.0.0-test",
+  });
+
+  for (const spec of Object.values(toolSpecs)) {
+    server.registerTool(
+      spec.name,
+      {
+        description: spec.description,
+        annotations: spec.annotations,
+        inputSchema: spec.inputShape,
+        outputSchema: spec.outputShape,
+      },
+      async (args: Record<string, unknown> | undefined) => {
+        const result = await handleTool(spec.name, args ?? {});
+        return toMcpResponse(result);
+      }
+    );
+  }
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+}
+
+describe("McpServer registration", () => {
+  it("advertises every tool in toolSpecs via listTools", async () => {
+    const { client } = await buildLinkedClient();
+    const { tools } = await client.listTools();
+    const advertised = new Set(tools.map((t) => t.name));
+    for (const expected of Object.keys(toolSpecs)) {
+      expect(advertised.has(expected)).toBe(true);
+    }
+    await client.close();
+  });
+
+  it("advertised tools carry the derived inputSchema", async () => {
+    const { client } = await buildLinkedClient();
+    const { tools } = await client.listTools();
+    const validate = tools.find((t) => t.name === "xano_validate_xanoscript");
+    expect(validate).toBeDefined();
+    expect(validate?.inputSchema).toMatchObject({
+      type: "object",
+      properties: expect.objectContaining({
+        code: expect.any(Object),
+        file_path: expect.any(Object),
+      }),
+    });
+    await client.close();
+  });
+
+  it("callTool round-trips successfully for xano_version", async () => {
+    const { client } = await buildLinkedClient();
+    const result = await client.callTool({ name: "xano_version", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(Array.isArray(result.content)).toBe(true);
+    await client.close();
+  });
+
+  it("invalid enum produces an isError tool response, not a transport failure", async () => {
+    const { client } = await buildLinkedClient();
+    const result = (await client.callTool({
+      name: "xano_xanoscript_docs",
+      arguments: { mode: "not_a_real_mode" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    // The error text should at least reference the offending field
+    expect(JSON.stringify(result.content)).toContain("mode");
+    await client.close();
+  });
+});

--- a/src/tools/mcp_version.ts
+++ b/src/tools/mcp_version.ts
@@ -107,7 +107,7 @@ export function mcpVersionTool(): ToolResult {
 // =============================================================================
 
 export const mcpVersionTool_spec = defineTool({
-  name: "mcp_version",
+  name: "xano_version",
   description:
     "Get the current version of the Xano Developer MCP server. " +
     "Returns the version string from package.json.",

--- a/src/tools/mcp_version.ts
+++ b/src/tools/mcp_version.ts
@@ -8,6 +8,8 @@
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { z } from "zod";
+import { defineTool } from "./define_tool.js";
 import type { ToolResult } from "./types.js";
 
 // =============================================================================
@@ -104,30 +106,23 @@ export function mcpVersionTool(): ToolResult {
 // MCP Tool Definition
 // =============================================================================
 
-export const mcpVersionToolDefinition = {
+export const mcpVersionTool_spec = defineTool({
   name: "mcp_version",
+  description:
+    "Get the current version of the Xano Developer MCP server. " +
+    "Returns the version string from package.json.",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: false,
   },
-  description:
-    "Get the current version of the Xano Developer MCP server. " +
-    "Returns the version string from package.json.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    required: [],
+  inputShape: {},
+  outputShape: {
+    version: z
+      .string()
+      .describe("The semantic version string of the MCP server."),
   },
-  outputSchema: {
-    type: "object",
-    properties: {
-      version: {
-        type: "string",
-        description: "The semantic version string of the MCP server.",
-      },
-    },
-    required: ["version"],
-  },
-};
+});
+
+export const mcpVersionToolDefinition = mcpVersionTool_spec.definition;

--- a/src/tools/mcp_version.ts
+++ b/src/tools/mcp_version.ts
@@ -106,7 +106,7 @@ export function mcpVersionTool(): ToolResult {
 // MCP Tool Definition
 // =============================================================================
 
-export const mcpVersionTool_spec = defineTool({
+export const mcpVersionToolSpec = defineTool({
   name: "xano_version",
   description:
     "Get the current version of the Xano Developer MCP server. " +
@@ -125,4 +125,3 @@ export const mcpVersionTool_spec = defineTool({
   },
 });
 
-export const mcpVersionToolDefinition = mcpVersionTool_spec.definition;

--- a/src/tools/meta_api_docs.ts
+++ b/src/tools/meta_api_docs.ts
@@ -8,6 +8,7 @@
 import {
   handleMetaApiDocs as _handleMetaApiDocs,
   metaApiDocsToolDefinition,
+  metaApiDocsTool_spec,
   topics,
   getTopicNames,
   getTopicDescriptions,
@@ -21,6 +22,7 @@ import type { ToolResult } from "./types.js";
 
 export {
   metaApiDocsToolDefinition,
+  metaApiDocsTool_spec,
   topics as metaApiTopics,
   getTopicNames as getMetaApiTopicNames,
   getTopicDescriptions as getMetaApiTopicDescriptions,

--- a/src/tools/meta_api_docs.ts
+++ b/src/tools/meta_api_docs.ts
@@ -7,8 +7,7 @@
 
 import {
   handleMetaApiDocs as _handleMetaApiDocs,
-  metaApiDocsToolDefinition,
-  metaApiDocsTool_spec,
+  metaApiDocsToolSpec,
   topics,
   getTopicNames,
   getTopicDescriptions,
@@ -21,8 +20,7 @@ import type { ToolResult } from "./types.js";
 // =============================================================================
 
 export {
-  metaApiDocsToolDefinition,
-  metaApiDocsTool_spec,
+  metaApiDocsToolSpec,
   topics as metaApiTopics,
   getTopicNames as getMetaApiTopicNames,
   getTopicDescriptions as getMetaApiTopicDescriptions,
@@ -97,5 +95,3 @@ export function metaApiDocsTool(args: MetaApiDocsArgs): ToolResult {
   }
 }
 
-// Re-export tool definition for MCP
-export { metaApiDocsToolDefinition as toolDefinition };

--- a/src/tools/meta_api_docs.ts
+++ b/src/tools/meta_api_docs.ts
@@ -77,7 +77,7 @@ export function metaApiDocsTool(args: MetaApiDocsArgs): ToolResult {
   if (!args?.topic) {
     return {
       success: false,
-      error: "Error: 'topic' parameter is required. Use meta_api_docs with topic='start' for overview.",
+      error: "Error: 'topic' parameter is required. Use xano_meta_api_docs with topic='start' for overview.",
     };
   }
 

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -16,6 +16,8 @@ import { getSchemeFromContent } from "@xano/xanoscript-language-server/utils.js"
 import { readFileSync, existsSync, readdirSync } from "fs";
 import { join, resolve, basename } from "path";
 import { minimatch } from "minimatch";
+import { z } from "zod";
+import { defineTool } from "./define_tool.js";
 import type { ToolResult } from "./types.js";
 
 // =============================================================================
@@ -524,27 +526,35 @@ export function validateXanoscript(
 export function validateXanoscriptTool(args: ValidateXanoscriptArgs): ToolResult {
   const result = validateXanoscript(args);
   if (result.valid) {
+    const warnings = countWarnings(result);
     return {
       success: true,
       data: result.message,
-      structuredContent: { valid: true, message: result.message },
+      structuredContent: { valid: true, message: result.message, warnings },
     };
   }
   return { success: false, error: result.message };
+}
+
+function countWarnings(
+  result: ValidationResult | BatchValidationResult
+): number {
+  if ("errors" in result) {
+    return result.errors.filter((e) => e.severity === SEVERITY.WARNING).length;
+  }
+  return result.results.reduce(
+    (sum, r) =>
+      sum + r.errors.filter((e) => e.severity === SEVERITY.WARNING).length,
+    0
+  );
 }
 
 // =============================================================================
 // MCP Tool Definition
 // =============================================================================
 
-export const validateXanoscriptToolDefinition = {
+export const validateXanoscriptTool_spec = defineTool({
   name: "validate_xanoscript",
-  annotations: {
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
   description:
     "Validate XanoScript code for syntax errors. Supports multiple input methods:\n" +
     "- code: Raw XanoScript code as a string\n" +
@@ -553,59 +563,67 @@ export const validateXanoscriptToolDefinition = {
     "- directory: Validate all .xs files in a directory\n\n" +
     "Returns errors with line/column positions and helpful suggestions for common mistakes. " +
     "The language server auto-detects the object type from the code syntax.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      code: {
-        type: "string",
-        description:
-          "The XanoScript code to validate as a string. Use file_path instead if the code contains special characters that are hard to escape. " +
-          "Example: \"var $name:text = 'hello'\\nreturn $name\"",
-      },
-      file_path: {
-        type: "string",
-        description:
-          "Path to a single XanoScript file to validate. Easier than passing code directly - avoids escaping issues. " +
-          "Example: \"function/format.xs\"",
-      },
-      file_paths: {
-        type: "array",
-        items: { type: "string" },
-        description:
-          "Array of file paths for batch validation. Returns a summary with per-file results. " +
-          "Example: [\"api/users/get.xs\", \"api/users/create.xs\", \"function/format.xs\"]",
-      },
-      directory: {
-        type: "string",
-        description:
-          "Directory path to validate. Validates all .xs files recursively. Use with 'pattern' to filter specific subdirectories or files. " +
-          "Example: \"api/users\"",
-      },
-      pattern: {
-        type: "string",
-        description:
-          "Glob pattern to filter files when using 'directory' (default: \"**/*.xs\"). " +
-          "Examples: \"api/**/*.xs\" to match only API files, \"**/create.xs\" to match all create files.",
-      },
-    },
-    required: [],
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
   },
-  outputSchema: {
-    type: "object",
-    properties: {
-      valid: {
-        type: "boolean",
-        description: "Whether the code passed validation without errors.",
-      },
-      message: {
-        type: "string",
-        description:
-          "Human-readable validation summary with error details if any.",
-      },
-    },
-    required: ["valid", "message"],
+  inputShape: {
+    code: z
+      .string()
+      .optional()
+      .describe(
+        "The XanoScript code to validate as a string. Use file_path instead if the code contains special characters that are hard to escape. " +
+          "Example: \"var $name:text = 'hello'\\nreturn $name\""
+      ),
+    file_path: z
+      .string()
+      .optional()
+      .describe(
+        "Path to a single XanoScript file to validate. Easier than passing code directly - avoids escaping issues. " +
+          'Example: "function/format.xs"'
+      ),
+    file_paths: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Array of file paths for batch validation. Returns a summary with per-file results. " +
+          'Example: ["api/users/get.xs", "api/users/create.xs", "function/format.xs"]'
+      ),
+    directory: z
+      .string()
+      .optional()
+      .describe(
+        "Directory path to validate. Validates all .xs files recursively. Use with 'pattern' to filter specific subdirectories or files. " +
+          'Example: "api/users"'
+      ),
+    pattern: z
+      .string()
+      .optional()
+      .describe(
+        'Glob pattern to filter files when using \'directory\' (default: "**/*.xs"). ' +
+          'Examples: "api/**/*.xs" to match only API files, "**/create.xs" to match all create files.'
+      ),
   },
-};
+  outputShape: {
+    valid: z
+      .boolean()
+      .describe("Whether the code passed validation without errors."),
+    message: z
+      .string()
+      .describe(
+        "Human-readable validation summary with error details if any."
+      ),
+    warnings: z
+      .number()
+      .optional()
+      .describe("Number of non-fatal warnings encountered, if any."),
+  },
+});
+
+export const validateXanoscriptToolDefinition =
+  validateXanoscriptTool_spec.definition;
 
 // =============================================================================
 // Utility Exports

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -554,7 +554,7 @@ function countWarnings(
 // =============================================================================
 
 export const validateXanoscriptTool_spec = defineTool({
-  name: "validate_xanoscript",
+  name: "xano_validate_xanoscript",
   description:
     "Validate XanoScript code for syntax errors. Supports multiple input methods:\n" +
     "- code: Raw XanoScript code as a string\n" +

--- a/src/tools/validate_xanoscript.ts
+++ b/src/tools/validate_xanoscript.ts
@@ -24,18 +24,14 @@ import type { ToolResult } from "./types.js";
 // Types
 // =============================================================================
 
-export interface ValidateXanoscriptArgs {
-  /** The XanoScript code to validate (mutually exclusive with file_path/file_paths/directory) */
-  code?: string;
-  /** Path to a single XanoScript file to validate */
-  file_path?: string;
-  /** Array of file paths for batch validation */
-  file_paths?: string[];
-  /** Directory to validate (validates all .xs files recursively) */
-  directory?: string;
-  /** Glob pattern to filter files when using directory (default: "**\/*.xs") */
-  pattern?: string;
-}
+/**
+ * Arguments for `validateXanoscript`. Derived from the Zod input shape below
+ * (see `validateXanoscriptToolSpec`) so the runtime parser and the static
+ * type can never drift.
+ */
+export type ValidateXanoscriptArgs = z.infer<
+  typeof validateXanoscriptToolSpec.inputParser
+>;
 
 export const SEVERITY = {
   ERROR: 1,
@@ -553,7 +549,7 @@ function countWarnings(
 // MCP Tool Definition
 // =============================================================================
 
-export const validateXanoscriptTool_spec = defineTool({
+export const validateXanoscriptToolSpec = defineTool({
   name: "xano_validate_xanoscript",
   description:
     "Validate XanoScript code for syntax errors. Supports multiple input methods:\n" +
@@ -621,9 +617,6 @@ export const validateXanoscriptTool_spec = defineTool({
       .describe("Number of non-fatal warnings encountered, if any."),
   },
 });
-
-export const validateXanoscriptToolDefinition =
-  validateXanoscriptTool_spec.definition;
 
 // =============================================================================
 // Utility Exports

--- a/src/tools/xanoscript_docs.ts
+++ b/src/tools/xanoscript_docs.ts
@@ -189,7 +189,7 @@ export function xanoscriptDocsTool(args?: XanoscriptDocsArgs): ToolResult {
 const topicEnumValues = getTopicNames() as [string, ...string[]];
 
 export const xanoscriptDocsTool_spec = defineTool({
-  name: "xanoscript_docs",
+  name: "xano_xanoscript_docs",
   description:
     "Get XanoScript programming language documentation for AI code generation. " +
     "Call without parameters for overview (README). " +

--- a/src/tools/xanoscript_docs.ts
+++ b/src/tools/xanoscript_docs.ts
@@ -56,17 +56,32 @@ export function getXanoscriptDocsPath(): string {
     join(__dirname, "..", "..", "xanoscript_docs"), // fallback
   ];
 
+  const errors: Array<{ path: string; code: string; message: string }> = [];
+
   for (const p of possiblePaths) {
     try {
       readFileSync(join(p, "version.json"));
       _docsPath = p;
       return p;
-    } catch {
-      continue;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code ?? "UNKNOWN";
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push({ path: p, code, message });
+      // ENOENT means "not this candidate, try next." Anything else is unusual
+      // (EACCES, malformed version.json) and worth surfacing.
+      if (code !== "ENOENT") {
+        console.error(
+          `[xanoscript_docs] Unexpected error reading ${p}/version.json: ${code} — ${message}`
+        );
+      }
     }
   }
 
-  // Default fallback
+  console.error(
+    "[xanoscript_docs] Could not locate version.json in any candidate path. " +
+      "Falling back to dist/xanoscript_docs. Candidates tried:\n" +
+      errors.map((e) => `  - ${e.path} (${e.code})`).join("\n")
+  );
   _docsPath = join(__dirname, "..", "xanoscript_docs");
   return _docsPath;
 }
@@ -188,7 +203,7 @@ export function xanoscriptDocsTool(args?: XanoscriptDocsArgs): ToolResult {
 
 const topicEnumValues = getTopicNames() as [string, ...string[]];
 
-export const xanoscriptDocsTool_spec = defineTool({
+export const xanoscriptDocsToolSpec = defineTool({
   name: "xano_xanoscript_docs",
   description:
     "Get XanoScript programming language documentation for AI code generation. " +
@@ -287,4 +302,3 @@ export const xanoscriptDocsTool_spec = defineTool({
   },
 });
 
-export const xanoscriptDocsToolDefinition = xanoscriptDocsTool_spec.definition;

--- a/src/tools/xanoscript_docs.ts
+++ b/src/tools/xanoscript_docs.ts
@@ -8,6 +8,7 @@
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { z } from "zod";
 import {
   readXanoscriptDocsV2,
   readXanoscriptDocsStructured,
@@ -17,6 +18,7 @@ import {
   type XanoscriptDocsArgs,
   type TopicDoc,
 } from "../xanoscript.js";
+import { defineTool } from "./define_tool.js";
 import type { ToolResult } from "./types.js";
 
 // =============================================================================
@@ -184,7 +186,9 @@ export function xanoscriptDocsTool(args?: XanoscriptDocsArgs): ToolResult {
 // MCP Tool Definition
 // =============================================================================
 
-export const xanoscriptDocsToolDefinition = {
+const topicEnumValues = getTopicNames() as [string, ...string[]];
+
+export const xanoscriptDocsTool_spec = defineTool({
   name: "xanoscript_docs",
   description:
     "Get XanoScript programming language documentation for AI code generation. " +
@@ -200,89 +204,87 @@ export const xanoscriptDocsToolDefinition = {
     idempotentHint: true,
     openWorldHint: false,
   },
-  inputSchema: {
-    type: "object",
-    properties: {
-      topic: {
-        type: "string",
-        enum: getTopicNames(),
-        description:
-          "Documentation topic to retrieve. Call without any parameters to get the README overview. " +
+  inputShape: {
+    topic: z
+      .enum(topicEnumValues)
+      .optional()
+      .describe(
+        "Documentation topic to retrieve. Call without any parameters to get the README overview. " +
           "Example: topic='syntax' for language syntax, topic='database' for database operations, topic='types' for type system.\n\n" +
-          "Available topics:\n" + getTopicDescriptions(),
-      },
-      file_path: {
-        type: "string",
-        description:
-          "File path being edited. Returns all relevant docs automatically based on the file type and location. " +
+          "Available topics:\n" +
+          getTopicDescriptions()
+      ),
+    file_path: z
+      .string()
+      .optional()
+      .describe(
+        "File path being edited. Returns all relevant docs automatically based on the file type and location. " +
           "Uses applyTo pattern matching to select applicable topics. " +
           "Example: 'api/users/create.xs' returns API, database, and syntax docs. " +
-          "'function/format.xs' returns function and syntax docs.",
-      },
-      mode: {
-        type: "string",
-        enum: ["full", "quick_reference", "index"],
-        description:
-          "'full' = complete documentation with explanations and examples. " +
+          "'function/format.xs' returns function and syntax docs."
+      ),
+    mode: z
+      .enum(["full", "quick_reference", "index"])
+      .optional()
+      .describe(
+        "'full' = complete documentation with explanations and examples. " +
           "'quick_reference' = compact reference with just syntax patterns and signatures. " +
           "'index' = compact topic listing with descriptions and byte sizes (~1KB). " +
           "Use 'index' to discover available topics before loading them. " +
           "Use 'quick_reference' to save context window space when you just need a reminder. " +
-          "Default: 'full' for topic mode, 'quick_reference' for file_path mode.",
-      },
-      tier: {
-        type: "string",
-        enum: ["survival", "working"],
-        description:
-          "Pre-packaged documentation tier for context-limited models. " +
+          "Default: 'full' for topic mode, 'quick_reference' for file_path mode."
+      ),
+    tier: z
+      .enum(["survival", "working"])
+      .optional()
+      .describe(
+        "Pre-packaged documentation tier for context-limited models. " +
           "'survival' (~3KB, ~800 tokens): minimum syntax to write valid XanoScript. " +
           "'working' (~12KB, ~3500 tokens): complete reference for common tasks. " +
           "Overrides topic/file_path/mode when set. " +
-          "Use 'survival' for models with <16K context, 'working' for 16-64K context.",
-      },
-      max_tokens: {
-        type: "number",
-        description:
-          "Maximum estimated token budget for documentation. " +
+          "Use 'survival' for models with <16K context, 'working' for 16-64K context."
+      ),
+    max_tokens: z
+      .number()
+      .optional()
+      .describe(
+        "Maximum estimated token budget for documentation. " +
           "When used with file_path, loads topics in priority order until budget is reached. " +
           "Helps prevent context overflow for small-window models. " +
-          "Estimate: 1KB of docs ≈ 250 tokens.",
-      },
-      exclude_topics: {
-        type: "array",
-        items: { type: "string" },
-        description:
-          "List of topic names to exclude from file_path results. " +
+          "Estimate: 1KB of docs ≈ 250 tokens."
+      ),
+    exclude_topics: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "List of topic names to exclude from file_path results. " +
           "Use this to skip topics you've already loaded (e.g., exclude_topics: ['syntax', 'essentials']). " +
-          "Only applies when using file_path parameter.",
-      },
-    },
-    required: [],
+          "Only applies when using file_path parameter."
+      ),
   },
-  outputSchema: {
-    type: "object",
-    properties: {
-      documentation: {
-        type: "string",
-        description: "The documentation content (topic or README mode).",
-      },
-      file_path: {
-        type: "string",
-        description: "The file path that was matched (file_path mode only).",
-      },
-      mode: {
-        type: "string",
-        description: "The documentation mode used.",
-      },
-      version: {
-        type: "string",
-        description: "The XanoScript documentation version.",
-      },
-      topics: {
-        type: "array",
-        items: { type: "string" },
-        description: "List of matched topic names (file_path mode only).",
-      },
-    },
+  outputShape: {
+    documentation: z
+      .string()
+      .optional()
+      .describe("The documentation content (topic or README mode)."),
+    file_path: z
+      .string()
+      .optional()
+      .describe("The file path that was matched (file_path mode only)."),
+    mode: z.string().optional().describe("The documentation mode used."),
+    tier: z
+      .string()
+      .optional()
+      .describe("The pre-packaged tier used, if any."),
+    version: z
+      .string()
+      .optional()
+      .describe("The XanoScript documentation version."),
+    topics: z
+      .array(z.string())
+      .optional()
+      .describe("List of matched topic names (file_path mode only)."),
   },
-};
+});
+
+export const xanoscriptDocsToolDefinition = xanoscriptDocsTool_spec.definition;

--- a/src/xanoscript_docs/README.md
+++ b/src/xanoscript_docs/README.md
@@ -93,7 +93,7 @@ project/
 
 Access with `$env.<name>`. Common built-in variables include `$env.$remote_ip`, `$env.$http_headers`, `$env.$request_method`, `$env.$datasource`, and `$env.$branch`. Custom environment variables are set in the Xano dashboard and accessed as `$env.MY_VAR`.
 
-For the complete list of system variables, see `xanoscript_docs({ topic: "syntax" })`.
+For the complete list of system variables, see `xano_xanoscript_docs({ topic: "syntax" })`.
 
 ## Core Syntax Patterns
 
@@ -118,7 +118,7 @@ $db.table.field     // Database field reference (in queries)
 $this               // Current item in loops/maps
 ```
 
-**Reserved Variables:** The following cannot be used as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`. See `xanoscript_docs({ topic: "essentials" })` for detailed variable access rules.
+**Reserved Variables:** The following cannot be used as variable names: `$response`, `$output`, `$input`, `$auth`, `$env`, `$db`, `$this`, `$result`, `$index`. See `xano_xano_xanoscript_docs({ topic: "essentials" })` for detailed variable access rules.
 
 ### Type Names
 
@@ -183,7 +183,7 @@ This helps AI tools apply the correct documentation based on the file being edit
 
 For common patterns and quick examples, use:
 ```
-xanoscript_docs({ topic: "essentials" })
+xano_xanoscript_docs({ topic: "essentials" })
 ```
 
 This includes:
@@ -197,7 +197,7 @@ This includes:
 
 ## Documentation Index
 
-Use `xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
+Use `xano_xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
 
 ### Tiers (for context-limited models)
 
@@ -206,7 +206,7 @@ Use `xanoscript_docs({ topic: "<topic>" })` to retrieve documentation.
 | `survival` | Minimal syntax survival kit for models with <16K context     | ~3KB (~800 tokens) |
 | `working`  | Complete working reference for models with 16-64K context    | ~12KB (~3500 tokens) |
 
-Use `xanoscript_docs({ tier: "survival" })` or `xanoscript_docs({ tier: "working" })`.
+Use `xano_xanoscript_docs({ tier: "survival" })` or `xano_xanoscript_docs({ tier: "working" })`.
 
 ### Core Language
 

--- a/src/xanoscript_docs/apis.md
+++ b/src/xanoscript_docs/apis.md
@@ -140,7 +140,7 @@ query "products" verb=GET {
 
 ## Input Block
 
-> **Input block rules:** Empty and single-input blocks can be one-liners. Multiple inputs must be on separate lines. For complete type reference, validation filters, and schema definitions, see `xanoscript_docs({ topic: "types" })`.
+> **Input block rules:** Empty and single-input blocks can be one-liners. Multiple inputs must be on separate lines. For complete type reference, validation filters, and schema definitions, see `xano_xanoscript_docs({ topic: "types" })`.
 
 ```xs
 // OK - empty or single input as one-liner
@@ -430,7 +430,7 @@ stack {
 
 ## Error Handling
 
-> **Error types:** Use `inputerror` (400), `accessdenied` (403), `notfound` (404), or `standard` (500). For complete error handling patterns including `precondition`, `try_catch`, and `throw`, see `xanoscript_docs({ topic: "syntax" })`.
+> **Error types:** Use `inputerror` (400), `accessdenied` (403), `notfound` (404), or `standard` (500). For complete error handling patterns including `precondition`, `try_catch`, and `throw`, see `xano_xanoscript_docs({ topic: "syntax" })`.
 
 ---
 

--- a/src/xanoscript_docs/database.md
+++ b/src/xanoscript_docs/database.md
@@ -636,7 +636,7 @@ try_catch {
 
 ## Related Topics
 
-Explore more with `xanoscript_docs({ topic: "<topic>" })`:
+Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:
 
 | Topic | Description |
 |-------|-------------|

--- a/src/xanoscript_docs/essentials.md
+++ b/src/xanoscript_docs/essentials.md
@@ -52,7 +52,7 @@ var $api_response { value = "test" }
 
 XanoScript uses specific type names. Common aliases from other languages won't work.
 
-> **Type names:** Use `text` (not string), `int` (not integer), `bool` (not boolean), `decimal` (not float). Full list: `xanoscript_docs({ topic: "types" })`
+> **Type names:** Use `text` (not string), `int` (not integer), `bool` (not boolean), `decimal` (not float). Full list: `xano_xanoscript_docs({ topic: "types" })`
 
 ### Variable Declaration
 
@@ -166,7 +166,7 @@ db.del "user" {
 }
 ```
 
-> **Full reference:** See `xanoscript_docs({ topic: "database" })` for joins, bulk operations, transactions, and more.
+> **Full reference:** See `xano_xanoscript_docs({ topic: "database" })` for joins, bulk operations, transactions, and more.
 
 ### API Requests
 
@@ -231,7 +231,7 @@ throw {
 
 `?` after the **type** = nullable, `?` after the **variable name** = optional (not required).
 
-> **Full reference:** See `xanoscript_docs({ topic: "types" })` for complete input types and validation options.
+> **Full reference:** See `xano_xanoscript_docs({ topic: "types" })` for complete input types and validation options.
 
 ```xs
 input {
@@ -289,7 +289,7 @@ $val|first_notnull:"default"  // Default if null
 $val ?? "default"             // Nullish coalescing
 ```
 
-> **Full reference:** See `xanoscript_docs({ topic: "syntax" })` for all 100+ filters organized by category (string, array, object, type, date, encoding).
+> **Full reference:** See `xano_xanoscript_docs({ topic: "syntax" })` for all 100+ filters organized by category (string, array, object, type, date, encoding).
 
 ### String Concatenation
 
@@ -409,7 +409,7 @@ var $response_data {
 
 ### 5. Date/Time Operations
 
-> **Full reference:** See `xanoscript_docs({ topic: "syntax" })` for all date/time filters.
+> **Full reference:** See `xano_xanoscript_docs({ topic: "syntax" })` for all date/time filters.
 
 ```xs
 var $now { value = now }
@@ -644,7 +644,7 @@ Each `.xs` file must contain exactly **one** construct. Placing two constructs i
 
 ## Related Topics
 
-Explore more with `xanoscript_docs({ topic: "<topic>" })`:
+Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:
 
 | Topic | Description |
 |-------|-------------|

--- a/src/xanoscript_docs/functions.md
+++ b/src/xanoscript_docs/functions.md
@@ -81,7 +81,7 @@ Reference with path: `function.run "math/add" { ... }`
 
 ## Input Block
 
-For complete type and filter reference, use `xanoscript_docs({ topic: "types" })`.
+For complete type and filter reference, use `xano_xanoscript_docs({ topic: "types" })`.
 
 `?` after the **type** = nullable (`text?`), `?` after the **variable name** = not required (`age?`).
 
@@ -183,7 +183,7 @@ stack {
 
 ### Error Handling
 
-For complete error handling reference (preconditions, try-catch, throw, early return), use `xanoscript_docs({ topic: "syntax" })`.
+For complete error handling reference (preconditions, try-catch, throw, early return), use `xano_xanoscript_docs({ topic: "syntax" })`.
 
 ---
 
@@ -464,7 +464,7 @@ foreach ($items) {
 
 ## Related Topics
 
-Explore more with `xanoscript_docs({ topic: "<topic>" })`:
+Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:
 
 | Topic | Description |
 |-------|-------------|

--- a/src/xanoscript_docs/integrations.md
+++ b/src/xanoscript_docs/integrations.md
@@ -10,11 +10,11 @@ applyTo: "function/**/*.xs, api/**/*.xs, task/*.xs"
 
 | Topic | Command | Contents |
 |-------|---------|----------|
-| Cloud Storage | `xanoscript_docs({ topic: "integrations/cloud-storage" })` | AWS S3, Azure Blob, GCP Storage |
-| Search | `xanoscript_docs({ topic: "integrations/search" })` | Elasticsearch, OpenSearch, Algolia |
-| Redis | `xanoscript_docs({ topic: "integrations/redis" })` | Caching, rate limiting, queues |
-| External APIs | `xanoscript_docs({ topic: "integrations/external-apis" })` | api.request patterns |
-| Utilities | `xanoscript_docs({ topic: "integrations/utilities" })` | Local storage, security, email, zip, Lambda |
+| Cloud Storage | `xano_xanoscript_docs({ topic: "integrations/cloud-storage" })` | AWS S3, Azure Blob, GCP Storage |
+| Search | `xano_xanoscript_docs({ topic: "integrations/search" })` | Elasticsearch, OpenSearch, Algolia |
+| Redis | `xano_xanoscript_docs({ topic: "integrations/redis" })` | Caching, rate limiting, queues |
+| External APIs | `xano_xanoscript_docs({ topic: "integrations/external-apis" })` | api.request patterns |
+| Utilities | `xano_xanoscript_docs({ topic: "integrations/utilities" })` | Local storage, security, email, zip, Lambda |
 
 ---
 

--- a/src/xanoscript_docs/middleware.md
+++ b/src/xanoscript_docs/middleware.md
@@ -280,7 +280,7 @@ middleware "cache_response" {
 
 ## Applying Middleware
 
-Middleware is configured at the branch level. See `xanoscript_docs({ topic: "branch" })` for configuration details.
+Middleware is configured at the branch level. See `xano_xanoscript_docs({ topic: "branch" })` for configuration details.
 
 ```xs
 branch "production" {

--- a/src/xanoscript_docs/performance.md
+++ b/src/xanoscript_docs/performance.md
@@ -137,7 +137,7 @@ db.bulk.add "order_item" {
 
 ## Caching Strategies
 
-> See `xanoscript_docs({ topic: "integrations/redis" })` for full Redis caching patterns (get/set, invalidation, computed value caching).
+> See `xano_xanoscript_docs({ topic: "integrations/redis" })` for full Redis caching patterns (get/set, invalidation, computed value caching).
 
 ---
 
@@ -157,7 +157,7 @@ db.query "product" {
 
 ## Rate Limiting
 
-For basic rate limiting setup, see `xanoscript_docs({ topic: "security" })`. Below are performance-focused patterns.
+For basic rate limiting setup, see `xano_xanoscript_docs({ topic: "security" })`. Below are performance-focused patterns.
 
 ### Tiered Limits
 
@@ -187,7 +187,7 @@ redis.ratelimit {
 
 For large responses, use `return = { type: "stream" }` with `api.stream` to avoid loading into memory. Large JSON responses are automatically compressed when clients support it.
 
-> See `xanoscript_docs({ topic: "streaming" })` for streaming patterns.
+> See `xano_xanoscript_docs({ topic: "streaming" })` for streaming patterns.
 
 ---
 
@@ -195,7 +195,7 @@ For large responses, use `return = { type: "stream" }` with `api.stream` to avoi
 
 Use `now|to_ms` before and after operations to measure duration, and `debug.log` to log slow queries.
 
-> See `xanoscript_docs({ topic: "debugging" })` for timing and logging patterns.
+> See `xano_xanoscript_docs({ topic: "debugging" })` for timing and logging patterns.
 
 ---
 

--- a/src/xanoscript_docs/realtime.md
+++ b/src/xanoscript_docs/realtime.md
@@ -261,7 +261,7 @@ api.realtime_event {
 
 ## Realtime Triggers
 
-Handle events from connected clients using `realtime_trigger`. For complete trigger syntax, input schemas, and configuration options, see `xanoscript_docs({ topic: "triggers" })`.
+Handle events from connected clients using `realtime_trigger`. For complete trigger syntax, input schemas, and configuration options, see `xano_xanoscript_docs({ topic: "triggers" })`.
 
 ---
 
@@ -286,7 +286,7 @@ api.realtime_event {
 
 Clients subscribe to channels client-side. Server controls what events to send. Validate channel access with preconditions before broadcasting.
 
-> See `xanoscript_docs({ topic: "security" })` for authorization patterns.
+> See `xano_xanoscript_docs({ topic: "security" })` for authorization patterns.
 
 ---
 

--- a/src/xanoscript_docs/security.md
+++ b/src/xanoscript_docs/security.md
@@ -258,7 +258,7 @@ security.jws_decode {
 } as $claims
 ```
 
-> See `xanoscript_docs({ topic: "integrations/utilities" })` for JWE, key generation, and other security utilities.
+> See `xano_xanoscript_docs({ topic: "integrations/utilities" })` for JWE, key generation, and other security utilities.
 
 ---
 

--- a/src/xanoscript_docs/survival.md
+++ b/src/xanoscript_docs/survival.md
@@ -4,7 +4,7 @@ applyTo: "**/*.xs"
 
 # XanoScript Survival Kit
 
-> Minimal reference for writing valid XanoScript. For more: `xanoscript_docs({ topic: "<topic>" })`.
+> Minimal reference for writing valid XanoScript. For more: `xano_xanoscript_docs({ topic: "<topic>" })`.
 
 ## Quick Reference
 

--- a/src/xanoscript_docs/syntax.md
+++ b/src/xanoscript_docs/syntax.md
@@ -25,9 +25,9 @@ Complete reference for XanoScript expressions, operators, and core filters. For 
 ### Extended Filter Sub-Topics
 
 For detailed references on specific filter categories, use:
-- `xanoscript_docs({ topic: "syntax/string-filters" })` — String filters, regex, encoding, security filters, text functions
-- `xanoscript_docs({ topic: "syntax/array-filters" })` — Array filters, functional operations, array functions
-- `xanoscript_docs({ topic: "syntax/functions" })` — Math filters/functions, object functions, bitwise operations
+- `xano_xanoscript_docs({ topic: "syntax/string-filters" })` — String filters, regex, encoding, security filters, text functions
+- `xano_xanoscript_docs({ topic: "syntax/array-filters" })` — Array filters, functional operations, array functions
+- `xano_xanoscript_docs({ topic: "syntax/functions" })` — Math filters/functions, object functions, bitwise operations
 
 ## CRITICAL: Filters Are Type-Specific
 
@@ -85,7 +85,7 @@ Working with...
 
 ### Variable Access Prefixes
 
-> **Full reference:** See `xanoscript_docs({ topic: "essentials" })` for detailed variable access rules, reserved variables, and type names.
+> **Full reference:** See `xano_xanoscript_docs({ topic: "essentials" })` for detailed variable access rules, reserved variables, and type names.
 
 | Prefix | Applies to | Shorthand? |
 |--------|-----------|------------|
@@ -256,7 +256,7 @@ $db.post.date >=? $input.start_date
 
 ## Type Filters
 
-> **Full reference:** For input types and validation, see `xanoscript_docs({ topic: "types" })`.
+> **Full reference:** For input types and validation, see `xano_xanoscript_docs({ topic: "types" })`.
 
 | Filter | Example | Result |
 |--------|---------|--------|
@@ -321,7 +321,7 @@ $ts|timestamp_day_of_week    // Day (0=Sunday)
 
 ## DB Query Filters
 
-> **Full reference:** For complete database operations, see `xanoscript_docs({ topic: "database" })`.
+> **Full reference:** For complete database operations, see `xano_xanoscript_docs({ topic: "database" })`.
 
 Used in `db.query` where clauses:
 
@@ -378,7 +378,7 @@ $db.created_at|timestamp_epoch_ms            // Milliseconds since epoch
 
 ### Vector Operations (AI/ML)
 
-> **Full reference:** For AI agents and embeddings, see `xanoscript_docs({ topic: "agents" })`.
+> **Full reference:** For AI agents and embeddings, see `xano_xanoscript_docs({ topic: "agents" })`.
 
 ```xs
 $db.embedding|l1_distance_manhattan:$input.vector    // L1/Manhattan distance
@@ -393,7 +393,7 @@ $db.boundary|covers:$input.point                     // Polygon covers point
 
 ### Preconditions
 
-Validate conditions and throw typed errors. See `xanoscript_docs({ topic: "essentials" })` for the error types reference table.
+Validate conditions and throw typed errors. See `xano_xanoscript_docs({ topic: "essentials" })` for the error types reference table.
 
 ```xs
 precondition ($input.amount > 0) {
@@ -494,7 +494,7 @@ var $api_key { value = $env.MY_API_KEY }
 
 ## Related Topics
 
-Explore more with `xanoscript_docs({ topic: "<topic>" })`:
+Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:
 
 | Topic | Description |
 |-------|-------------|

--- a/src/xanoscript_docs/syntax/string-filters.md
+++ b/src/xanoscript_docs/syntax/string-filters.md
@@ -163,7 +163,7 @@ $data|csv_create                             // Create CSV string
 
 ## Security Filters
 
-> **Full reference:** See `xanoscript_docs({ topic: "security" })` for security best practices.
+> **Full reference:** See `xano_xanoscript_docs({ topic: "security" })` for security best practices.
 
 | Filter | Example |
 |--------|---------|

--- a/src/xanoscript_docs/tools.md
+++ b/src/xanoscript_docs/tools.md
@@ -66,7 +66,7 @@ tool "get_user_by_email" {
 
 ## Input Block
 
-For complete type reference, use `xanoscript_docs({ topic: "types" })`. For tools, input `description` fields are sent to the AI, so write them clearly:
+For complete type reference, use `xano_xanoscript_docs({ topic: "types" })`. For tools, input `description` fields are sent to the AI, so write them clearly:
 
 ```xs
 input {
@@ -256,7 +256,7 @@ tool "get_order_with_items" {
 
 ## Error Handling
 
-For complete error handling reference (preconditions, try-catch, throw, error types), see `xanoscript_docs({ topic: "syntax" })`.
+For complete error handling reference (preconditions, try-catch, throw, error types), see `xano_xanoscript_docs({ topic: "syntax" })`.
 
 ```xs
 tool "cancel_order" {

--- a/src/xanoscript_docs/types.md
+++ b/src/xanoscript_docs/types.md
@@ -421,7 +421,7 @@ input {
 
 ## Validation with Preconditions
 
-For complex validation beyond filters, use preconditions. For complete error handling reference, use `xanoscript_docs({ topic: "syntax" })`.
+For complex validation beyond filters, use preconditions. For complete error handling reference, use `xano_xanoscript_docs({ topic: "syntax" })`.
 
 ```xs
 precondition ($input.start_date < $input.end_date) {
@@ -442,7 +442,7 @@ precondition ($input.start_date < $input.end_date) {
 
 ## Related Topics
 
-Explore more with `xanoscript_docs({ topic: "<topic>" })`:
+Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:
 
 | Topic | Description |
 |-------|-------------|

--- a/src/xanoscript_docs/unit-testing.md
+++ b/src/xanoscript_docs/unit-testing.md
@@ -366,7 +366,7 @@ function "create_user" {
 }
 ```
 
-For a full breakdown of what each required/optional/nullable combination accepts, see `xanoscript_docs({ topic: "types" })`.
+For a full breakdown of what each required/optional/nullable combination accepts, see `xano_xanoscript_docs({ topic: "types" })`.
 
 ---
 

--- a/src/xanoscript_docs/workflow-tests.md
+++ b/src/xanoscript_docs/workflow-tests.md
@@ -296,7 +296,7 @@ workflow_test "comprehensive_test" {
 
 1. **Use `function.call`, not `function.run`** — `function.call` handles errors so that `expect` assertions work correctly
 2. **Keep tests independent** — Each workflow test should be self-contained
-3. **Don't test required fields with empty strings** — Required inputs reject `""` at the platform level. Use optional fields (`text name?`) to test blank cases. See `xanoscript_docs({ topic: "types" })`
+3. **Don't test required fields with empty strings** — Required inputs reject `""` at the platform level. Use optional fields (`text name?`) to test blank cases. See `xano_xanoscript_docs({ topic: "types" })`
 
 ---
 

--- a/src/xanoscript_docs/working.md
+++ b/src/xanoscript_docs/working.md
@@ -4,7 +4,7 @@ applyTo: "**/*.xs"
 
 # XanoScript Working Reference
 
-> Complete reference for common XanoScript development. Call `xanoscript_docs({ topic: "<topic>" })` for specialized topics.
+> Complete reference for common XanoScript development. Call `xano_xanoscript_docs({ topic: "<topic>" })` for specialized topics.
 
 ## Quick Reference
 
@@ -380,7 +380,7 @@ function.run "send_notification" {
 }
 ```
 
-> For async patterns, recursion, and advanced function features: `xanoscript_docs({ topic: "functions" })`
+> For async patterns, recursion, and advanced function features: `xano_xanoscript_docs({ topic: "functions" })`
 
 ---
 
@@ -475,7 +475,7 @@ db.transaction {
 }
 ```
 
-> For bulk operations, direct SQL, vector search, and advanced queries: `xanoscript_docs({ topic: "database" })`
+> For bulk operations, direct SQL, vector search, and advanced queries: `xano_xanoscript_docs({ topic: "database" })`
 
 ---
 
@@ -555,7 +555,7 @@ query "users/{user_id}" verb=DELETE {
 }
 ```
 
-> For API groups, rate limiting, file uploads, and custom headers: `xanoscript_docs({ topic: "apis" })`
+> For API groups, rate limiting, file uploads, and custom headers: `xano_xanoscript_docs({ topic: "apis" })`
 
 ---
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- Migrate the MCP server from the low-level `Server` API to `McpServer` with `registerTool` / `registerResource`.
- Make each tool's Zod input/output shape the single source of truth — JSON Schema sent to clients is now derived from Zod via `z.toJSONSchema`, so wire-level schemas and the runtime parser can never drift.
- Normalize all tool names under a `xano_` prefix for consistent discoverability.

## Breaking Changes (Major Bump)

### Tool renames (MCP clients)

| 1.x | 2.0 |
|---|---|
| `validate_xanoscript` | `xano_validate_xanoscript` |
| `xanoscript_docs` | `xano_xanoscript_docs` |
| `meta_api_docs` | `xano_meta_api_docs` |
| `cli_docs` | `xano_cli_docs` |
| `mcp_version` | `xano_version` |

### Library API

- `handleTool(name, args)` is now `async` and returns `Promise<ToolResult>`. Consumers must `await` it.
- Individual `*ToolDefinition` exports removed — use `toolSpecs[name].definition` instead. The high-level functions (`validateXanoscript`, `xanoscriptDocs`, `metaApiDocs`, `cliDocs`, `mcpVersion`) are unchanged. README upgrade section covers both migrations.

## Notable Fixes

- **`xano_xanoscript_docs` `tier` / `max_tokens` parameters now work.** Documented but silently stripped by the hand-maintained Zod schema in 1.x. Now derived from the Zod shape, so they pass through.
- **`xano_validate_xanoscript`** success results now include a `warnings` count in `structuredContent`.

## New

- `src/tools/define_tool.ts` — builds an MCP tool definition from Zod shapes; sanitizes `$schema` and `additionalProperties` out of the emitted JSON Schema.
- `toolSpecs` library export — exposes each tool's Zod input/output shape; `ToolName` type enumerates registered names.
- Typed dispatch table in `handleTool` — adding to `toolSpecs` without a handler is now a compile error.
- `zod` declared in `dependencies` (was only transitively present via the MCP SDK).

## Hardening from PR review (commits 3845ee3, b223db8)

- Handler exceptions in `registerTool` / `registerResource` are caught and returned as structured tool errors instead of escaping as transport-level failures.
- `getXanoscriptDocsPath` no longer silently swallows non-ENOENT errors; logs every candidate path tried before falling back.
- `parseWithSpec` error format includes Zod issue codes for better debuggability.
- `ToolDefinition` / `BuiltTool` fields now `readonly`; branded `JsonSchema` type.
- Build no longer ships test files: separate `tsconfig.build.json` excludes `**/*.test.ts`; build wipes `dist/` first so stale artifacts from older layouts can't leak into the tarball.

## Test Plan

- [x] `npm run build` — clean (dist contains 5 tool modules + lib + xanoscript_docs, no test files, no stale folders)
- [x] `npm test` — 200/200 passing (was 185 before review; +15 tests for `defineTool` schema derivation, `McpServer` `InMemoryTransport` smoke test, warnings count, validation field-mention)
- [x] `npx tsc --noEmit` — clean
- [x] Published `2.0.0-beta.0` to npm and end-to-end smoke-tested all 5 tools via live MCP connection in Claude Code:
  - `xano_version` returns `2.0.0-beta.0`
  - `xano_validate_xanoscript` returns errors with type-alias suggestions
  - `xano_xanoscript_docs({ tier: "survival" })` returns docs (regression fix confirmed)
  - `xano_meta_api_docs` / `xano_cli_docs` return docs

## Release notes / docs

- `README.md` "Upgrading from 1.x to 2.0" section covers the renames, async `handleTool`, and removed `*ToolDefinition` exports with migration snippets.
- All Available Tools / Library Usage / How It Works examples updated to new names.
- XanoScript documentation cross-references in `src/xanoscript_docs/*.md` updated to `xano_xanoscript_docs({...})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)