### PR TITLE
chore(deps): update @xano/xanoscript-language-server to ^12.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@xano/xanoscript-language-server": "^12.0.0",
+        "@xano/xanoscript-language-server": "^12.3.0",
         "minimatch": "^10.1.2",
         "zod": "^4.0.0"
       },
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@xano/xanoscript-language-server": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-12.2.0.tgz",
-      "integrity": "sha512-hRF1hQT5ufABtmPKjxTBFk47BdqtYFpHYCEkAmykbTw1yE+JJxBsGa+BgJKHT72MVTd4pKuSwgAxZXCT2Sx3eQ==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-12.3.0.tgz",
+      "integrity": "sha512-8lvW73//0S7h/evgWnutAnUiKoi0MxfzCqLtDA7BKCaFzY8DlVc1M74754pknePqanLuDbP9AFIGQkF+JThRNA==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@xano/xanoscript-language-server": "^12.0.0",
+    "@xano/xanoscript-language-server": "^12.3.0",
     "minimatch": "^10.1.2",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
- Bumps `@xano/xanoscript-language-server` from `^12.0.0` to `^12.3.0`
- Build verified clean (`npm run build`)

## Test plan
- [ ] CI passes
- [ ] Verify MCP server functions correctly with updated language server

🤖 Generated with [Claude Code](https://claude.com/claude-code)