### PR TITLE
docs(cli): sync cli_docs with CLI v1.0.2-beta.3 and document safety markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.0",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/cli_docs/topics/branch.ts
+++ b/src/cli_docs/topics/branch.ts
@@ -52,11 +52,13 @@ Xano CLI commands are SPACE-separated (e.g. \`xano branch list\`), not colon-sep
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" },
         { name: "profile", short: "p", type: "string", required: false, description: "Profile name to use" },
+        { name: "backups", type: "boolean", required: false, default: "false", description: "Include backup branches in the output" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
       ],
       examples: [
         "xano branch list",
         "xano branch list -w 123",
+        "xano branch list --backups",
         "xano branch list --output json"
       ]
     },

--- a/src/cli_docs/topics/release.ts
+++ b/src/cli_docs/topics/release.ts
@@ -185,24 +185,23 @@ Xano CLI commands are SPACE-separated (e.g. \`xano release list\`), not colon-se
     },
     {
       name: "release push",
-      description: "Push a local directory as a new release. Directory is the -d/--directory flag (default: current directory), not a positional argument.",
+      description: "Push a local directory as a new release. Directory is the -d/--directory flag (default: current directory), not a positional argument. The release is bound to the directory's branch — there is no `--branch` flag.",
       usage: "xano release push -n <name> [options]",
       flags: [
         { name: "name", short: "n", type: "string", required: true, description: "Name for the new release" },
-        { name: "directory", short: "d", type: "string", required: false, default: ".", description: "Local directory containing files to push as a release (defaults to current directory)" },
-        { name: "branch", short: "b", type: "string", required: false, description: "Branch to associate the release with" },
+        { name: "directory", short: "d", type: "string", required: false, default: ".", description: "Local directory containing .xs documents to push as a release (defaults to current directory)" },
         { name: "hotfix", type: "boolean", required: false, default: "false", description: "Mark this release as a hotfix" },
         { name: "description", type: "string", required: false, description: "Description for the release" },
         { name: "records", type: "boolean", required: false, default: "true", description: "Include records (default: true; use --no-records to exclude)" },
         { name: "env", type: "boolean", required: false, default: "true", description: "Include environment variables (default: true; use --no-env to exclude)" },
-        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile workspace if not provided)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" },
         { name: "profile", short: "p", type: "string", required: false, description: "Profile name to use" }
       ],
       examples: [
         "xano release push -n v1.0.0",
         "xano release push -d ./release-v1 -n v1.0.0",
-        'xano release push -d ./release-v1 -n v1.1.0 -b dev --description "Staging release"',
+        'xano release push -d ./release-v1 -n v1.1.0 --description "Staging release"',
         "xano release push -n hotfix-1 --hotfix --no-records --no-env"
       ]
     },

--- a/src/cli_docs/topics/start.ts
+++ b/src/cli_docs/topics/start.ts
@@ -71,6 +71,19 @@ All commands support:
 - \`XANO_CONFIG\` - Override the credentials file path (same effect as \`-c\`)
 - \`XANO_VERBOSE\` - Enable verbose logging (same effect as \`-v\`)
 
+## Safety Markers (\`[CRITICAL]\` and \`[IMPORTANT]\`)
+
+Destructive commands and flags are prefixed with one of two imperative markers in their description, usage, and help text. These are not stylistic — they signal required agent behavior:
+
+- **\`[CRITICAL]\`** — Irreversible or large-blast-radius operation (data loss, destroyed restore points, truncated tables, disabled rollback, removed clusters, replaced env vars). **NEVER run a \`[CRITICAL]\` command or flag without explicit user confirmation in the current turn.** Prior approval of a similar command does not carry over. The accompanying imperative verb (\`NEVER\`, \`STOP\`, \`DO NOT\`) tells you the exact required action.
+- **\`[IMPORTANT]\`** — Mutates shared/live state but is reversible or has a preview path. **ALWAYS run \`--dry-run\` first (when available) and surface the output to the user before proceeding.** Confirm intent if the user has not already approved this specific action.
+
+When you see either marker, pause and acknowledge it to the user before invoking the command — do not auto-accept it just because the broader task was approved.
+
+Examples of where these markers appear:
+- \`[CRITICAL]\` flags: \`--force\` on any \`delete\`, \`workspace push --sync --delete\`, \`--truncate\`, \`--no-transaction\`, \`--records\` (when pushing live data), \`tenant backup restore\`, \`tenant cluster delete\`, \`sandbox reset\`, \`env set_all --clean\`.
+- \`[IMPORTANT]\` base commands: \`workspace push\`, \`sandbox push\`, \`branch set_live\`, \`release import\`, \`release push\`.
+
 ## Command Categories
 
 | Category | Description |
@@ -89,7 +102,9 @@ All commands support:
 | \`static_host\` | Deploy static sites |
 | \`update\` | Update CLI to latest version |`,
 
-  ai_hints: `**Important:** The CLI is optional - not all users will have it installed. Before suggesting CLI commands, check if the user has it available or ask if they'd like to install it. The Meta API can accomplish the same tasks programmatically.
+  ai_hints: `**Safety markers (full definitions in description above):** When you see \`[CRITICAL]\` on a command or flag, NEVER run it without explicit user confirmation in the current turn — prior approval does not carry over. When you see \`[IMPORTANT]\`, ALWAYS run \`--dry-run\` first (when available) and show the user the output before the real run. The imperative verb in the marker (\`NEVER\`, \`ALWAYS\`, \`STOP\`, \`DO NOT\`) is the literal required action.
+
+**Important:** The CLI is optional - not all users will have it installed. Before suggesting CLI commands, check if the user has it available or ask if they'd like to install it. The Meta API can accomplish the same tasks programmatically.
 
 **When to use CLI vs Meta API:**
 - Use CLI for: local development, code sync, quick execution, scripting

--- a/src/cli_docs/topics/start.ts
+++ b/src/cli_docs/topics/start.ts
@@ -81,8 +81,9 @@ Destructive commands and flags are prefixed with one of two imperative markers i
 When you see either marker, pause and acknowledge it to the user before invoking the command — do not auto-accept it just because the broader task was approved.
 
 Examples of where these markers appear:
-- \`[CRITICAL]\` flags: \`--force\` on any \`delete\`, \`workspace push --sync --delete\`, \`--truncate\`, \`--no-transaction\`, \`--records\` (when pushing live data), \`tenant backup restore\`, \`tenant cluster delete\`, \`sandbox reset\`, \`env set_all --clean\`.
-- \`[IMPORTANT]\` base commands: \`workspace push\`, \`sandbox push\`, \`branch set_live\`, \`release import\`, \`release push\`.
+- \`[CRITICAL]\` flags: \`--force\` on any \`delete\`, \`workspace push --sync --delete\`, \`--truncate\`, \`--no-transaction\`, \`--records\` (when pushing live data).
+- \`[CRITICAL]\` commands: \`tenant backup restore\`, \`tenant cluster delete\`, \`tenant deploy_platform\`, \`tenant env set_all\`, \`sandbox env set_all\`, \`sandbox reset\`, \`sandbox delete\`, \`workspace delete\`.
+- \`[IMPORTANT]\` base commands: \`workspace push\`, \`sandbox push\`, \`branch set_live\`, \`release import\`, \`release push\`, \`release deploy\`.
 
 ## Command Categories
 

--- a/src/cli_docs/topics/static_host.ts
+++ b/src/cli_docs/topics/static_host.ts
@@ -75,19 +75,19 @@ export const staticHostDoc: TopicDoc = {
     },
     {
       name: "static_host build get",
-      description: "Get details of a specific build",
-      usage: "xano static_host build get <host_name> <build_id>",
+      description: "Get details of a specific build. Positional order is `<build_id> <static_host>` per the CLI's argument schema.",
+      usage: "xano static_host build get <build_id> <static_host>",
       args: [
-        { name: "host_name", required: true, description: "Static host name" },
-        { name: "build_id", required: true, description: "Build ID" }
+        { name: "build_id", required: true, description: "Build ID" },
+        { name: "static_host", required: true, description: "Static host name" }
       ],
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
       ],
       examples: [
-        "xano static_host build get my-app 52",
-        "xano static_host build get my-app 52 -o json"
+        "xano static_host build get 52 my-app",
+        "xano static_host build get 52 my-app -o json"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Audited every topic in `src/cli_docs/topics/` against `xano --help` output from the CLI repo at v1.0.2-beta.3 and fixed three concrete drifts.
- Added a Safety Markers section to the `start` topic that defines what `[CRITICAL]` and `[IMPORTANT]` mean in command/flag descriptions (DEV-6104, mirroring [xano-inc/cli#8](https://github.com/xano-inc/cli/pull/8)).

### Drifts fixed

- **`branch list`** — added missing `--backups` flag.
- **`release push`** — removed `-b/--branch` flag that no longer exists in the CLI (release is bound to the source directory's branch).
- **`static_host build get`** — corrected positional argument order to `<build_id> <static_host>` to match the CLI's `static args` schema (the CLI's own help examples are inverted; the schema governs parsing).

### Safety markers

Defines the imperative-verb convention so MCP-driven agents pause before destructive ops:

- `[CRITICAL]` → NEVER run without explicit user confirmation in the current turn. Prior approval doesn't carry over.
- `[IMPORTANT]` → ALWAYS run `--dry-run` first when available and show the user the output.
- The verb in the marker (`NEVER`, `ALWAYS`, `STOP`, `DO NOT`) is the literal required action.

Placed the full definition in `description` (always rendered) with a tight directive in `ai_hints` to avoid duplicating context tokens.

## Test plan

- [x] `npm run build` — green
- [x] `npm test` — 200/200 passing
- [ ] Reviewer: spot-check `xano_cli_docs` output for `start`, `branch`, `release`, `static_host` looks right
- [ ] Reviewer: confirm safety-marker phrasing matches the CLI-side PR ([xano-inc/cli#8](https://github.com/xano-inc/cli/pull/8))

🤖 Generated with [Claude Code](https://claude.com/claude-code)