### PR TITLE
chore(deps): update @xano/xanoscript-language-server to ^12.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "2.0.1",
+      "version": "2.0.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
-        "@xano/xanoscript-language-server": "^12.3.0",
+        "@xano/xanoscript-language-server": "^12.4.0",
         "minimatch": "^10.1.2",
         "zod": "^4.0.0"
       },
@@ -1072,9 +1072,9 @@
       }
     },
     "node_modules/@xano/xanoscript-language-server": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-12.3.0.tgz",
-      "integrity": "sha512-8lvW73//0S7h/evgWnutAnUiKoi0MxfzCqLtDA7BKCaFzY8DlVc1M74754pknePqanLuDbP9AFIGQkF+JThRNA==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@xano/xanoscript-language-server/-/xanoscript-language-server-12.4.0.tgz",
+      "integrity": "sha512-OQnGHonhjNQ8cJvW5+jM+tBw7UGbag9fD5n5LLOgrE87B9Hil8LwW7WXjxUhR++qza0tu4S64zeSdu1WwpBwIw==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.2-beta.0",
+  "version": "2.0.2-beta.1",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",
@@ -61,7 +61,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@xano/xanoscript-language-server": "^12.3.0",
+    "@xano/xanoscript-language-server": "^12.4.0",
     "minimatch": "^10.1.2",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
- Bump `@xano/xanoscript-language-server` from `^12.3.0` to `^12.4.0`
- Refresh `package-lock.json`

DEV-7011

## Test plan
- [ ] CI passes
- [ ] `npm install` resolves cleanly
- [ ] XanoScript validation tool still works against sample scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)