### PR TITLE
docs: scope call statements to their home primitive

### DIFF
--- a/src/xanoscript_docs/tools.md
+++ b/src/xanoscript_docs/tools.md
@@ -82,6 +82,8 @@ input {
 
 ## Tool-Specific Statements
 
+> **Where these belong:** `api.call`, `task.call`, and `tool.call` are for **tools**. Use them to compose a tool from other Xano constructs. Don't reach for them in API endpoints, functions, or tasks. (To call a function from a regular stack, use `function.run`.)
+
 ### api.call
 Call an API endpoint:
 

--- a/src/xanoscript_docs/workflow-tests.md
+++ b/src/xanoscript_docs/workflow-tests.md
@@ -28,6 +28,8 @@ workflow_test "<name>" {
 
 Call functions invoke Xano constructs and capture their results. Each returns a result that can be stored with `as $variable`.
 
+> **Where these belong:** Call functions are for **workflow tests**. Don't reach for them in API endpoints, functions, or tasks. (To call a function from a regular stack, use `function.run` — see the [`function.call`](#functioncall) note below.)
+
 | Call Function     | Description                    | Required Properties                  |
 | ----------------- | ------------------------------ | ------------------------------------ |
 | `api.call`        | Call an API endpoint           | `api_group`, `verb` (on call), optional `headers` |


### PR DESCRIPTION
## What

Adds short "where these belong" notes to two docs so AI code generation stops emitting `.call` statements in the wrong contexts:

- **tools.md** — `api.call`, `task.call`, `tool.call` are scoped to **tools**.
- **workflow-tests.md** — the call functions are scoped to **workflow tests**.

Both notes steer away from API endpoints, functions, and tasks, and point to `function.run` for calling a function from a regular stack.

## Why

The validator confirms `api.call` (and friends) only parse inside `workflow_test`, `tool`, or `test` contexts, yet AI was adding them to API endpoints and functions. These notes guide codegen to the right home without documenting the technical edge cases.

## Notes

- No "technically allowed elsewhere" caveats — intentional, to keep the steer clean.
- `version.json` left at `2.2.0` (clarification, not a fact change).
- All 211 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)