### PR TITLE
docs(cli): sync cli_docs with CLI v1.0.3-beta.8, bump to 2.2.1-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.0.5",
+  "version": "2.2.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xano/developer-mcp",
-      "version": "2.0.5",
+      "version": "2.2.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xano/developer-mcp",
-  "version": "2.2.0",
+  "version": "2.2.1-beta.0",
   "description": "MCP server and library for Xano development - XanoScript validation, Meta API, Run API, and CLI documentation",
   "type": "module",
   "main": "dist/lib.js",

--- a/src/cli_docs/topics/auth.ts
+++ b/src/cli_docs/topics/auth.ts
@@ -5,18 +5,27 @@ export const authDoc: TopicDoc = {
   title: "Xano CLI - Authentication",
   description: `The \`auth\` command provides browser-based OAuth authentication for the Xano CLI. It opens your browser, lets you log in to your Xano account, and automatically creates a profile with your credentials.
 
-## How It Works
+## How It Works (default flow)
 
-1. CLI starts a local HTTP server on a random port
+1. CLI starts a local HTTP server on a random port (127.0.0.1)
 2. Opens your browser to the Xano login page
 3. After login, Xano redirects back to the local server with your token
 4. CLI validates the token, lets you select instance/workspace/branch
 5. Saves the profile to \`~/.xano/credentials.yaml\`
 
-The authentication flow has a 5-minute timeout.`,
+The authentication flow has a 5-minute timeout.
+
+## Headless Flow (\`--no-browser\`)
+
+On remote/SSH sessions, Docker containers, or locked-down networks where the browser can't reach the CLI's loopback address, use \`--no-browser\`: the CLI prints a login URL, you open it in any browser, and paste back the code it displays. No local callback server required.
+
+## Pre-selecting with Flags
+
+Each interactive picker can be pre-answered with a flag: \`-i/--instance\` (instance name), \`-w/--workspace\` (workspace ID or name), \`-b/--branch\` (branch label), and \`-p/--profile\` (profile name to save). An empty value (\`""\`) takes the picker's default answer: \`-w ""\` skips workspace selection, \`-b ""\` skips and uses the live branch, \`-p ""\` uses the default profile name. With all four set alongside \`--no-browser\`, the only input is pasting the code from the browser — useful for scripted or remote setups.`,
 
   ai_hints: `**auth vs profile wizard:**
 - \`xano auth\` - Browser-based OAuth login (recommended for interactive use)
+- \`xano auth --no-browser\` - Headless login: open the printed URL in any browser, paste back the code (for SSH/Docker/remote hosts)
 - \`xano profile wizard\` - Token-based interactive setup (requires manually copying token)
 - \`xano profile create\` - Non-interactive, requires all flags
 
@@ -24,11 +33,15 @@ The authentication flow has a 5-minute timeout.`,
 - User is setting up CLI for the first time
 - User doesn't have an access token handy
 - User prefers browser-based login
+- User is in a headless/SSH environment: use \`xano auth --no-browser\`
 
-**When to suggest profile wizard instead:**
+**When to suggest profile wizard/create instead:**
 - User already has an access token
-- User is in a headless/SSH environment without browser access
-- User needs non-interactive setup (CI/CD)
+- User needs fully non-interactive setup (CI/CD) — \`profile create\` requires no prompts at all
+
+**Flag meaning caution:** On \`xano auth\`, \`-p/--profile\` is the *profile name to save*, not the profile-selection flag that other commands use. Backup branches are filtered out of the branch picker.
+
+**Self-hosted note:** With a non-default \`--origin\`, the origin itself is the instance, so \`--instance\` is ignored.
 
 **After auth, suggest \`xano sandbox\`:**
 The sandbox is a free-tier personal dev environment (auto-provisioned singleton tenant) ideal for experimenting without touching production.`,
@@ -42,13 +55,21 @@ The sandbox is a free-tier personal dev environment (auto-provisioned singleton 
       usage: "xano auth [options]",
       flags: [
         { name: "origin", short: "o", type: "string", required: false, default: "https://app.xano.com", description: "Xano account origin URL. Use this to point at a custom/self-hosted Xano instance." },
+        { name: "no-browser", type: "boolean", required: false, description: "Headless login: print a URL and paste back the code shown in the browser, instead of starting a local callback server (use on remote/SSH/Docker hosts where 127.0.0.1 is not reachable from the browser)" },
+        { name: "instance", short: "i", type: "string", required: false, description: "Pre-select an instance by name (skips the instance picker). Ignored for self-hosted origins." },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Pre-select a workspace by ID or name (skips the workspace picker); pass \"\" to skip workspace" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Pre-select a branch by label (skips the branch picker); pass \"\" to skip and use the live branch" },
+        { name: "profile", short: "p", type: "string", required: false, description: "Profile name to save (skips the profile name prompt); pass \"\" to use the default name. Note: unlike other commands, -p here names the profile being created." },
         { name: "insecure", short: "k", type: "boolean", required: false, description: "Skip TLS certificate verification (for self-signed certificates)" },
         { name: "config", short: "c", type: "string", required: false, description: "Path to credentials file (default: ~/.xano/credentials.yaml). Env: XANO_CONFIG" }
       ],
       examples: [
         "xano auth",
         "xano auth --origin https://custom.xano.com",
-        "xano auth -k  # for self-signed certificates"
+        "xano auth -k  # for self-signed certificates",
+        "xano auth --no-browser  # headless: paste the code shown in the browser",
+        "xano auth -i my-instance -w 5 -b dev -p staging  # pre-answer all pickers",
+        "xano auth --no-browser -i my-instance -w \"\" -b \"\" -p \"\"  # scripted setup, only the code prompt remains"
       ]
     }
   ],
@@ -67,6 +88,19 @@ The sandbox is a free-tier personal dev environment (auto-provisioned singleton 
       ],
       example: `npm install -g @xano/cli
 xano auth
+xano profile me`
+    },
+    {
+      name: "Headless Setup (SSH/Docker/Remote)",
+      description: "Authenticate on a host where the browser cannot reach the CLI's local callback server",
+      steps: [
+        "Run: `xano auth --no-browser` (add -i/-w/-b/-p to skip the pickers)",
+        "Open the printed URL in any browser and log in",
+        "Copy the code shown in the browser and paste it into the CLI prompt",
+        "Verify: `xano profile me`"
+      ],
+      example: `xano auth --no-browser -i my-instance -w 5 -b dev -p staging
+# open the printed URL in any browser, paste back the code
 xano profile me`
     }
   ]

--- a/src/cli_docs/topics/profile.ts
+++ b/src/cli_docs/topics/profile.ts
@@ -25,7 +25,35 @@ profiles:
     workspace: 1
     branch: 2           # staging branch
 default: production
-\`\`\``,
+\`\`\`
+
+## Project-Local Profile (\`profile.yaml\`)
+
+To avoid accidentally targeting the wrong workspace, pin a project to a profile by adding a \`profile.yaml\` file at the project root. The CLI searches the current directory and walks up parent directories (like \`.git\`) to find it.
+
+\`profile.yaml\` contains **no secrets** — it references a profile by name; the access token always comes from \`~/.xano/credentials.yaml\`. An \`access_token\` key is rejected, and \`insecure\` cannot be set from a project file (security boundary).
+
+\`\`\`yaml
+# ./profile.yaml
+profile: staging          # which credentials.yaml profile to use
+workspace: 110            # optional override
+instance_origin: https://your-instance.xano.io        # optional override
+account_origin: https://app.xano.com                  # optional override
+branch: main              # optional override
+\`\`\`
+
+When a \`profile.yaml\` is in effect, every command prints the active target, e.g. \`Using profile 'staging' (workspace 110) · profile.yaml\` (suppressed for \`--output json\` and credential-management commands).
+
+Generate one with \`xano profile use <name>\` — it writes a self-documenting \`profile.yaml\` (every overridable field included as a commented example) and offers to add it to \`.gitignore\`.
+
+## Profile Selection Precedence
+
+1. \`-p/--profile\` flag
+2. \`XANO_PROFILE\` environment variable
+3. \`profile.yaml\` (\`profile:\` field, plus field overrides)
+4. Default profile from the credentials file
+
+An explicit \`-p/--profile\` or \`XANO_PROFILE\` ignores \`profile.yaml\` entirely (name and overrides).`,
 
   ai_hints: `**Use profiles for:**
 - Different environments (production, staging, development)
@@ -39,7 +67,13 @@ default: production
 **Switching contexts:**
 - Use \`-p <profile>\` flag on any command
 - Or set \`XANO_PROFILE\` environment variable
-- Or use \`profile set\` to change default
+- Or pin a project with \`xano profile use <name>\` (writes ./profile.yaml)
+- Or use \`profile set\` to change the global default
+
+**Suggest \`profile use\` when:**
+- User juggles multiple workspaces/projects and could push to the wrong one by forgetting \`-p\`
+- A repo should always target a specific profile/workspace regardless of the user's global default
+- Remember: profile.yaml is overridden entirely by an explicit \`-p\` or \`XANO_PROFILE\`
 
 **Alternative auth methods:**
 - \`xano auth\` - Browser-based OAuth login (no token needed)
@@ -129,6 +163,28 @@ default: production
       examples: ["xano profile delete old-profile", "xano profile delete test --force"]
     },
     {
+      name: "profile use",
+      description: "Pin a profile for the current project by writing a local profile.yaml. When present, the CLI uses this profile (and any overrides) instead of the default, unless -p/--profile or XANO_PROFILE is set. Warns before overwriting an existing profile.yaml and offers to add it to .gitignore (skipped if already ignored).",
+      usage: "xano profile use <name> [options]",
+      args: [
+        { name: "name", required: true, description: "Profile name (from credentials.yaml) to pin for this project" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Override workspace for this project" },
+        { name: "branch", short: "b", type: "string", required: false, description: "Override branch for this project" },
+        { name: "instance_origin", short: "i", type: "string", required: false, description: "Override instance origin for this project" },
+        { name: "account_origin", short: "a", type: "string", required: false, description: "Override account origin for this project" },
+        { name: "gitignore", type: "boolean", required: false, description: "Add profile.yaml to .gitignore without prompting (--no-gitignore to skip the prompt without adding)" },
+        { name: "config", short: "c", type: "string", required: false, description: "Path to credentials file (default: ~/.xano/credentials.yaml). Env: XANO_CONFIG" }
+      ],
+      examples: [
+        "xano profile use staging",
+        "xano profile use staging -w 110",
+        "xano profile use staging -w 110 --gitignore",
+        "xano profile use staging --no-gitignore"
+      ]
+    },
+    {
       name: "profile set",
       description: "Set the default profile",
       usage: "xano profile set <name>",
@@ -192,6 +248,19 @@ default: production
         "Set default: `xano profile set prod`",
         "Use staging when needed: `xano workspace pull ./code -p staging`"
       ]
+    },
+    {
+      name: "Pin a Project to a Profile",
+      description: "Prevent commands in a project directory from targeting the wrong workspace",
+      steps: [
+        "From the project root: `xano profile use staging -w 110`",
+        "Accept the prompt to add profile.yaml to .gitignore (or pass --gitignore)",
+        "Commands run inside the project now print `Using profile 'staging' (workspace 110) · profile.yaml`",
+        "Override per-command when needed with `-p <other-profile>` (ignores profile.yaml entirely)"
+      ],
+      example: `cd my-project
+xano profile use staging -w 110 --gitignore
+xano workspace pull -d ./code   # uses 'staging', workspace 110`
     }
   ]
 };

--- a/src/cli_docs/topics/sandbox.ts
+++ b/src/cli_docs/topics/sandbox.ts
@@ -105,9 +105,10 @@ export const sandboxDoc: TopicDoc = {
       usage: "xano sandbox review [options]",
       flags: [
         { name: "url-only", short: "u", type: "boolean", required: false, description: "Print the URL without opening the browser" },
+        { name: "insecure", short: "k", type: "boolean", required: false, description: "Skip TLS certificate verification (for self-signed certificates)" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
       ],
-      examples: ["xano sandbox review", "xano sandbox review --url-only"]
+      examples: ["xano sandbox review", "xano sandbox review --url-only", "xano sandbox review --insecure"]
     },
     {
       name: "sandbox impersonate",

--- a/src/cli_docs/topics/start.ts
+++ b/src/cli_docs/topics/start.ts
@@ -34,7 +34,7 @@ npm link
 \`\`\`bash
 xano auth
 \`\`\`
-Opens your browser to log in. Automatically creates a profile.
+Opens your browser to log in. Automatically creates a profile. On remote/SSH/Docker hosts where the browser can't reach the CLI, use \`xano auth --no-browser\` (prints a URL; paste back the code shown in the browser).
 
 **Option 2: Interactive wizard**
 \`\`\`bash
@@ -71,6 +71,10 @@ All commands support:
 - \`XANO_CONFIG\` - Override the credentials file path (same effect as \`-c\`)
 - \`XANO_VERBOSE\` - Enable verbose logging (same effect as \`-v\`)
 
+## Project-Local Profile (\`profile.yaml\`)
+
+A project can be pinned to a specific profile (and optional workspace/branch/origin overrides) by a \`profile.yaml\` at the project root — generated with \`xano profile use <name>\`. The CLI discovers it by walking up parent directories. It contains no secrets (the token always comes from credentials.yaml), and an explicit \`-p\`/\`XANO_PROFILE\` overrides it entirely. See the "profile" topic for details.
+
 ## Safety Markers (\`[CRITICAL]\` and \`[IMPORTANT]\`)
 
 Destructive commands and flags are prefixed with one of two imperative markers in their description, usage, and help text. These are not stylistic — they signal required agent behavior:
@@ -100,7 +104,7 @@ Examples of where these markers appear:
 | \`unit_test\` | Run unit tests |
 | \`workflow_test\` | Run workflow tests |
 | \`platform\` | View available platform versions |
-| \`static_host\` | Deploy static sites |
+| \`static_host\` | Manage static hosts, push builds, deploy to dev/prod |
 | \`update\` | Update CLI to latest version |`,
 
   ai_hints: `**Safety markers (full definitions in description above):** When you see \`[CRITICAL]\` on a command or flag, NEVER run it without explicit user confirmation in the current turn — prior approval does not carry over. When you see \`[IMPORTANT]\`, ALWAYS run \`--dry-run\` first (when available) and show the user the output before the real run. The imperative verb in the marker (\`NEVER\`, \`ALWAYS\`, \`STOP\`, \`DO NOT\`) is the literal required action.
@@ -121,7 +125,10 @@ Examples of where these markers appear:
 **Profile selection priority:**
 1. \`-p\` flag on command
 2. \`XANO_PROFILE\` environment variable
-3. Default profile in credentials.yaml`,
+3. Project-local \`profile.yaml\` (created with \`xano profile use\`; discovered by walking up parent directories)
+4. Default profile in credentials.yaml
+
+An explicit \`-p\` or \`XANO_PROFILE\` ignores \`profile.yaml\` entirely. When a profile.yaml is in effect, commands print the active target (e.g. \`Using profile 'staging' (workspace 110) · profile.yaml\`).`,
 
   related_topics: ["auth", "profile", "workspace", "sandbox", "integration"],
 

--- a/src/cli_docs/topics/static_host.ts
+++ b/src/cli_docs/topics/static_host.ts
@@ -3,12 +3,28 @@ import type { TopicDoc } from "../types.js";
 export const staticHostDoc: TopicDoc = {
   topic: "static_host",
   title: "Xano CLI - Static Hosting",
-  description: `Static host commands let you deploy frontend builds to Xano's static hosting infrastructure.`,
+  description: `Static host commands let you create and manage static hosts, push frontend builds, and deploy them to dev/prod environments on Xano's static hosting infrastructure.
+
+## Concepts
+
+- **Static host**: A named hosting target in a workspace. Each host has a **dev** and a **prod** environment, each with its own URL.
+- **Build**: An uploaded snapshot of your site (a directory or zip). Builds are created with \`build push\` and deployed to an environment with \`deploy\`.
+- **Git config**: A host can optionally be linked to a git repository (\`edit --git-repo\` plus SSH keys).
+- **v1 vs v2 hosting**: v2 is instance-managed hosting. Older v1 hosts can be moved with \`static_host migrate\`.`,
 
   ai_hints: `**Static hosting workflow:**
-1. Build your frontend (React, Vue, etc.)
-2. Zip the build output
-3. Upload with \`static_host build create\`
+1. Create a host once: \`xano static_host create my-app\`
+2. Build your frontend (React, Vue, etc.)
+3. Push the build output directory: \`xano static_host build push my-app -d ./dist -n "v1.0.0"\`
+4. Deploy it: \`xano static_host deploy my-app --build_id <id> --env dev\` (then \`--env prod\`)
+
+**Prefer \`build push\` over \`build create\`:** \`build create\` is deprecated and hidden — \`build push -f <file>\` covers the zip-upload case, and \`build push -d <dir>\` (or no flag for the current directory) zips and uploads a directory for you. The build name is optional (auto-generated from the timestamp). For package.json builds, push waits for the build to finish unless \`--no-wait\`.
+
+**build get/delete/deploy take \`--build_id\` as a flag**, not a positional argument (older CLI versions used positionals).
+
+**\`build pull\` source selection:** defaults to the original uploaded source (including package.json); use \`--source built\` for the compiled/served output. Select the build by \`--build_id\`, \`--latest\`, or \`--env dev|prod\` (the build currently deployed there).
+
+**Destructive:** \`build delete\` is permanent and prompts for confirmation; its \`--force\` flag is marked [CRITICAL] — never run it without explicit user confirmation.
 
 **Use cases:**
 - Deploy SPAs built with modern frameworks
@@ -37,30 +53,112 @@ export const staticHostDoc: TopicDoc = {
       ]
     },
     {
-      name: "static_host build create",
-      description: "Create a new build for a static host by uploading a ZIP file",
-      usage: "xano static_host build create <host_name> -f <file> -n <name> [options]",
+      name: "static_host create",
+      description: "Create a new static host in the workspace",
+      usage: "xano static_host create <name> [options]",
       args: [
-        { name: "host_name", required: true, description: "Static host name" }
+        { name: "name", required: true, description: "Name for the new static host" }
       ],
       flags: [
-        { name: "file", short: "f", type: "string", required: true, description: "Path to ZIP file to upload" },
-        { name: "name", short: "n", type: "string", required: true, description: "Build name/version" },
-        { name: "description", short: "d", type: "string", required: false, description: "Build description" },
+        { name: "description", type: "string", required: false, description: "Description for the static host" },
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
       ],
       examples: [
-        "xano static_host build create my-app -f ./build.zip -n 'v1.0.0'",
-        "xano static_host build create my-app -f ./dist.zip -n 'v1.1.0' -d 'Bug fixes'"
+        "xano static_host create marketing",
+        "xano static_host create marketing --description 'Marketing site' -w 40"
+      ]
+    },
+    {
+      name: "static_host get",
+      description: "Get a single static host's details (name, git config, dev/prod environments and URLs)",
+      usage: "xano static_host get <static_host> [options]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host get my-app",
+        "xano static_host get my-app -w 40 -o json"
+      ]
+    },
+    {
+      name: "static_host edit",
+      description: "Update a static host's name, description, or git configuration. Renaming changes the deployed hostname.",
+      usage: "xano static_host edit <static_host> [options]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name to edit" }
+      ],
+      flags: [
+        { name: "name", type: "string", required: false, description: "New name for the static host (renaming changes the deployed hostname)" },
+        { name: "description", type: "string", required: false, description: "New description for the static host" },
+        { name: "git-repo", type: "string", required: false, description: "Git repository URL (e.g. git@github.com:org/repo.git)" },
+        { name: "git-public-key", type: "string", required: false, description: "Git SSH public key" },
+        { name: "git-private-key-file", type: "string", required: false, description: "Path to a file containing the git SSH private key (read from disk; never passed on the command line)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host edit my-app --description 'Marketing site'",
+        "xano static_host edit my-app --name my-app-v2",
+        "xano static_host edit my-app --git-repo git@github.com:me/site.git --git-private-key-file ./deploy_key"
+      ]
+    },
+    {
+      name: "static_host build push",
+      description: "Push a directory or zip file as a new static host build. Defaults to the current directory; the build name is auto-generated from the timestamp if omitted. For package.json builds, waits for the build to finish unless --no-wait.",
+      usage: "xano static_host build push <static_host> [options]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "directory", short: "d", type: "string", required: false, description: "Directory to push (defaults to current directory). Mutually exclusive with --file." },
+        { name: "file", short: "f", type: "string", required: false, description: "Path to a zip file to upload (alternative to -d). Mutually exclusive with --directory." },
+        { name: "name", short: "n", type: "string", required: false, description: "Build name (auto-generated from the current timestamp if omitted)" },
+        { name: "description", type: "string", required: false, description: "Build description" },
+        { name: "no-wait", type: "boolean", required: false, description: "Return immediately after upload instead of waiting for the build to finish" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host build push my-app -d ./dist -n 'v1.0.0'",
+        "xano static_host build push my-app  # current dir, auto-named",
+        "xano static_host build push my-app -f ./build.zip -n 'v1.0.0'",
+        "xano static_host build push my-app -n 'release' --description 'Production build'"
+      ]
+    },
+    {
+      name: "static_host build pull",
+      description: "Pull a static host build to disk. Defaults to the original uploaded source (including package.json); use --source built for the compiled/served output. Select the build by --build_id, --latest, or --env (mutually exclusive).",
+      usage: "xano static_host build pull <static_host> (--build_id <id> | --latest | --env <dev|prod>) [options]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "build_id", type: "string", required: false, description: "Build ID to pull. Mutually exclusive with --latest and --env." },
+        { name: "latest", type: "boolean", required: false, description: "Pull the latest build. Mutually exclusive with --build_id and --env." },
+        { name: "env", type: "string", required: false, description: "Pull the build currently deployed to this environment (dev or prod). Mutually exclusive with --build_id and --latest." },
+        { name: "directory", short: "d", type: "string", required: false, default: ".", description: "Output directory for pulled files (defaults to current directory)" },
+        { name: "source", type: "string", required: false, default: "original", description: "Which files to pull: 'original' (the uploaded source, including package.json) or 'built' (the compiled/served output)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" }
+      ],
+      examples: [
+        "xano static_host build pull my-app --build_id 52",
+        "xano static_host build pull my-app --build_id 52 --source built",
+        "xano static_host build pull my-app --latest",
+        "xano static_host build pull my-app --env dev",
+        "xano static_host build pull my-app --env prod -d ./prod-release"
       ]
     },
     {
       name: "static_host build list",
       description: "List all builds for a static host",
-      usage: "xano static_host build list <host_name> [-w <workspace>]",
+      usage: "xano static_host build list <static_host> [-w <workspace>]",
       args: [
-        { name: "host_name", required: true, description: "Static host name" }
+        { name: "static_host", required: true, description: "Static host name" }
       ],
       flags: [
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
@@ -75,19 +173,96 @@ export const staticHostDoc: TopicDoc = {
     },
     {
       name: "static_host build get",
-      description: "Get details of a specific build. Positional order is `<build_id> <static_host>` per the CLI's argument schema.",
-      usage: "xano static_host build get <build_id> <static_host>",
+      description: "Get details of a specific build for a static host. The build is selected with the --build_id flag (not a positional argument).",
+      usage: "xano static_host build get <static_host> --build_id <id>",
       args: [
-        { name: "build_id", required: true, description: "Build ID" },
         { name: "static_host", required: true, description: "Static host name" }
       ],
       flags: [
+        { name: "build_id", type: "string", required: true, description: "Build ID" },
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
         { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
       ],
       examples: [
-        "xano static_host build get 52 my-app",
-        "xano static_host build get 52 my-app -o json"
+        "xano static_host build get my-app --build_id 52",
+        "xano static_host build get my-app --build_id 52 -o json"
+      ]
+    },
+    {
+      name: "static_host build delete",
+      description: "Delete a static host build permanently. This action cannot be undone. Prompts for confirmation unless --force.",
+      usage: "xano static_host build delete <static_host> --build_id <id> [--force]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "build_id", type: "string", required: true, description: "Build ID to delete" },
+        { name: "force", short: "f", type: "boolean", required: false, description: "[CRITICAL] NEVER run without explicit user confirmation. Skips the confirmation prompt." },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host build delete my-app --build_id 52",
+        "xano static_host build delete my-app --build_id 52 --force"
+      ]
+    },
+    {
+      name: "static_host deploy",
+      description: "Deploy a static host build to an environment (dev or prod). Prints the deployed URL.",
+      usage: "xano static_host deploy <static_host> --build_id <id> --env <dev|prod>",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "build_id", type: "string", required: true, description: "Build ID to deploy" },
+        { name: "env", type: "string", required: true, description: "Target environment: dev or prod" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host deploy my-app --build_id 52 --env dev",
+        "xano static_host deploy my-app --build_id 52 --env prod",
+        "xano static_host deploy my-app --build_id 52 --env prod -o json"
+      ]
+    },
+    {
+      name: "static_host migrate",
+      description: "Migrate a static host to instance-managed (v2) hosting. Reparents the Ingress, verifies it, clears master, and marks the host v2. Migrates both environments unless --env is given.",
+      usage: "xano static_host migrate [static_host] [--all] [--env <dev|prod>] [--dry-run]",
+      args: [
+        { name: "static_host", required: false, description: "Static host name to migrate (omit when using --all)" }
+      ],
+      flags: [
+        { name: "all", type: "boolean", required: false, description: "Migrate every host still on v1 in the workspace" },
+        { name: "dry-run", type: "boolean", required: false, description: "List the hosts that would be migrated without changing anything" },
+        { name: "env", type: "string", required: false, description: "Which environment to migrate: dev or prod (migrates both if omitted)" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host migrate my-app",
+        "xano static_host migrate my-app --env dev",
+        "xano static_host migrate --all --dry-run",
+        "xano static_host migrate --all"
+      ]
+    },
+    {
+      name: "static_host build create",
+      description: "[Deprecated: use 'static_host build push -f <file>' instead] Create a new build from a zip file. Hidden from CLI help.",
+      usage: "xano static_host build create <static_host> -f <file> [options]",
+      args: [
+        { name: "static_host", required: true, description: "Static host name" }
+      ],
+      flags: [
+        { name: "file", short: "f", type: "string", required: true, description: "Path to ZIP file to upload" },
+        { name: "name", short: "n", type: "string", required: false, description: "Build name (auto-generated from the current timestamp if omitted)" },
+        { name: "description", short: "d", type: "string", required: false, description: "Build description" },
+        { name: "no-wait", type: "boolean", required: false, description: "Return immediately after upload instead of waiting for the build to finish" },
+        { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (optional if set in profile)" },
+        { name: "output", short: "o", type: "string", required: false, default: "summary", description: "Output format: summary or json" }
+      ],
+      examples: [
+        "xano static_host build push my-app -f ./build.zip -n 'v1.0.0'  # preferred replacement"
       ]
     }
   ],
@@ -95,15 +270,35 @@ export const staticHostDoc: TopicDoc = {
   workflows: [
     {
       name: "Deploy Frontend",
-      description: "Build and deploy a frontend application",
+      description: "Build, push, and deploy a frontend application",
       steps: [
+        "Create the host once: `xano static_host create my-app`",
         "Build your app: `npm run build`",
-        "Create ZIP: `zip -r build.zip dist/`",
-        "Deploy: `xano static_host build create my-app -f build.zip -n 'v1.0.0'`"
+        "Push the build output: `xano static_host build push my-app -d ./dist -n 'v1.0.0'`",
+        "Deploy to dev: `xano static_host deploy my-app --build_id <id> --env dev`",
+        "Verify, then deploy to prod: `xano static_host deploy my-app --build_id <id> --env prod`"
       ],
-      example: `npm run build
-zip -r build.zip dist/
-xano static_host build create my-frontend -f build.zip -n 'v1.0.0' -d 'Initial release'`
+      example: `xano static_host create my-frontend
+npm run build
+xano static_host build push my-frontend -d ./dist -n 'v1.0.0'
+xano static_host deploy my-frontend --build_id 52 --env dev
+xano static_host deploy my-frontend --build_id 52 --env prod`
+    },
+    {
+      name: "Roll Back a Deployment",
+      description: "Deploy a previous build to an environment",
+      steps: [
+        "List builds: `xano static_host build list my-app`",
+        "Deploy the previous build ID: `xano static_host deploy my-app --build_id <old_id> --env prod`"
+      ]
+    },
+    {
+      name: "Recover Build Source",
+      description: "Pull the source of a deployed build back to disk",
+      steps: [
+        "Pull what's live in prod: `xano static_host build pull my-app --env prod -d ./recovered`",
+        "Or pull the compiled output: `xano static_host build pull my-app --env prod --source built -d ./recovered`"
+      ]
     }
   ]
 };


### PR DESCRIPTION
## Summary

Syncs the `xano_cli_docs` topics with the Xano CLI at **v1.0.3-beta.8** (last synced against v1.0.2-beta.3 in #48) and bumps the package version to **2.2.1-beta.0** (just published).

### CLI changes documented

- **auth** — new `--no-browser` headless login flow (print URL, paste back code — for SSH/Docker hosts), plus `-i/--instance`, `-w/--workspace`, `-b/--branch`, `-p/--profile` pre-select flags with `""` empty-value semantics. Added a headless setup workflow and a note that `-p` on `auth` names the profile being *created*.
- **profile** — new `xano profile use <name>` command and the project-local `profile.yaml` system: no secrets allowed (`access_token` rejected, `insecure` not settable), parent-directory discovery, active-target banner, and the updated 4-level selection precedence (`-p` > `XANO_PROFILE` > `profile.yaml` > default).
- **static_host** — biggest gap: host CRUD (`create`, `get`, `edit` with git config flags), `build push` (directory or zip, auto-named, waits for package.json builds unless `--no-wait`), `build pull` (`--build_id`/`--latest`/`--env`, `--source original|built`), `build delete` (with `[CRITICAL]` `--force` marker), `deploy` (`--env dev|prod`), and `migrate` (v1→v2, `--all`, `--dry-run`). Marked `build create` deprecated in favor of `build push -f`, and fixed `build get` to the new `--build_id` flag form (old docs described a removed positional form).
- **sandbox** — `review --insecure` flag.
- **start** — headless auth mention, `profile.yaml` precedence, refreshed static_host category description.

Bug-fix-only CLI changes (triggers in partial push, double-confirm fix) were reviewed and intentionally not documented.

Also syncs the stale `package-lock.json` version (was 2.0.5).

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 218/218 tests pass
- [x] All five updated topics render correctly through `handleCliDocs` at `detailed` and `examples` levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)