### PR TITLE
docs: AI-facing doc improvements (validation, push, static hosting)

### DIFF
--- a/src/cli_docs/topics/workspace.ts
+++ b/src/cli_docs/topics/workspace.ts
@@ -223,13 +223,13 @@ For lighter-weight iterative development without pulling the whole workspace, se
     },
     {
       name: "workspace push",
-      description: "Upload local XanoScript files to a workspace. Default mode is partial (only changed files). Use --sync for a full push. The source directory is the -d/--directory flag (default: current directory), not a positional argument.",
+      description: "Upload local XanoScript files to a workspace. Default mode is partial (only changed files). Use --sync for a full push. The source directory is the -d/--directory flag (default: current directory), not a positional argument. A partial push is additive, not declarative: it adds and updates but makes no destructive changes (it won't drop a removed column or relax a constraint), so local files and the live workspace can diverge. Use --sync for destructive changes; --dry-run to preview.",
       usage: "xano workspace push [options]",
       flags: [
         { name: "directory", short: "d", type: "string", required: false, default: ".", description: "Directory containing documents to push (defaults to current directory)" },
         { name: "workspace", short: "w", type: "string", required: false, description: "Workspace ID (uses profile default if not set)" },
         { name: "branch", short: "b", type: "string", required: false, description: "Branch label to push to (defaults to live branch or profile branch)" },
-        { name: "sync", type: "boolean", required: false, default: "false", description: "Full push (default is partial/changed-only). Required for --delete." },
+        { name: "sync", type: "boolean", required: false, default: "false", description: "Full push (default is partial/changed-only). Required for --delete and for destructive schema changes (a partial push never drops or relaxes anything)." },
         { name: "delete", type: "boolean", required: false, default: "false", description: "Delete remote objects not present in local files (requires --sync)" },
         { name: "dry-run", type: "boolean", required: false, default: "false", description: "Preview changes without applying" },
         { name: "force", type: "boolean", required: false, default: "false", description: "Skip preview and confirmation prompt (for CI/CD)" },

--- a/src/xanoscript_docs/docs_index.json
+++ b/src/xanoscript_docs/docs_index.json
@@ -184,10 +184,10 @@
     },
     "frontend": {
       "file": "frontend.md",
-      "description": "Static frontend development and deployment",
+      "description": "Static frontend development and deployment (static hosting)",
       "applyTo": ["static/**/*"],
       "priority": 3,
-      "aliases": ["static", "html", "css", "web"]
+      "aliases": ["static", "html", "css", "web", "spa", "hosting", "static-host", "deploy"]
     },
     "addons": {
       "file": "addons.md",

--- a/src/xanoscript_docs/essentials.md
+++ b/src/xanoscript_docs/essentials.md
@@ -668,6 +668,12 @@ See `xano_xanoscript_docs({ topic: "file-uploads" })` for the full pattern.
 
 ---
 
+## Validation is syntax-only
+
+`xano_validate_xanoscript` checks syntax, not runtime behavior. A `valid` result means the code parses — it can still fail at execution (often a 500). Validation is necessary but not sufficient: after it passes, `push` and run the endpoint once (`validate → push → run`) before trusting the code.
+
+---
+
 ## Related Topics
 
 Explore more with `xano_xanoscript_docs({ topic: "<topic>" })`:

--- a/src/xanoscript_docs/frontend.md
+++ b/src/xanoscript_docs/frontend.md
@@ -4,153 +4,81 @@ applyTo: "static/**/*"
 
 # Frontend
 
-Static frontend development with Xano APIs.
+Build a static frontend (any framework that emits static output, or plain
+HTML/CSS/JS) that calls your Xano APIs directly, then deploy it to **Xano static
+hosting** (paid plans). There's no server tier — only static files; all dynamic
+data comes from your APIs.
 
-## Quick Reference
+Keep frontend source in a **`static/`** directory at the project root, beside the
+backend code.
 
-### Directory Structure
-```
-static/
-├── index.html              // Main entry point
-├── css/
-├── js/
-│   └── api.js              // Centralized API calls
-└── assets/
-```
+## Get the API spec first
 
-### Key Tools
-| Tool | Purpose |
-|------|---------|
-| `get_xano_api_specifications` | Get OpenAPI specs before frontend work |
-| `upload_static_files_to_xano` | Deploy to Xano CDN |
+Before wiring calls, get the OpenAPI/Swagger spec for the API group you'll
+consume: the `xano_get_openapi_spec` tool (if exposed), the Meta API `/openapi`
+endpoint (see `xano_meta_api_docs`), or the API group's `…/swagger.json` URL.
+It also drives typed-client codegen in the starter below.
 
----
+## Two starting points
 
-## Base Template
+- **Opinionated starter (recommended for apps)** — clone
+  [`xano-labs/static_template`](https://github.com/xano-labs/static_template) into
+  `static/`: a Vite + React + TS SPA with auth and typed API hooks (generated from
+  your Swagger) already wired. Point it at your instance (`VITE_XANO_API_BASE` +
+  `VITE_XANO_SWAGGER_URL`) and build. It ships its own docs — follow those.
 
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>My App</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-</head>
-<body>
-  <div id="app"></div>
-  <script src="js/api.js"></script>
-  <script src="js/app.js"></script>
-</body>
-</html>
-```
+- **Plain static (no build)** — hand-write files into `static/`. Centralize calls
+  in one client module that prefixes a base URL and attaches the auth token:
 
----
+  ```javascript
+  const API_BASE = 'https://your-instance.xano.io/api:group';
 
-## API Client
-
-### Basic Setup (api.js)
-```javascript
-const API_BASE = 'https://your-instance.xano.io/api:group';
-
-async function apiCall(endpoint, options = {}) {
-  const token = localStorage.getItem('auth_token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token && { 'Authorization': `Bearer ${token}` })
-  };
-
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers: { ...headers, ...options.headers }
-  });
-
-  if (!response.ok) {
-    throw new Error(`API Error: ${response.status}`);
+  async function apiCall(endpoint, options = {}) {
+    const token = localStorage.getItem('auth_token');
+    const res = await fetch(`${API_BASE}${endpoint}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
+        ...options.headers,
+      },
+    });
+    if (!res.ok) throw new Error(`API Error: ${res.status}`);
+    return res.json();
   }
+  ```
 
-  return response.json();
-}
+  Auth follows the same pattern: `POST /auth/login` (or `/auth/signup`) returns an
+  `authToken`; store it in `localStorage`, send it as `Authorization: Bearer`, and
+  remove it to log out.
 
-// CRUD helpers
-const api = {
-  get: (endpoint) => apiCall(endpoint),
-  post: (endpoint, data) => apiCall(endpoint, {
-    method: 'POST',
-    body: JSON.stringify(data)
-  }),
-  patch: (endpoint, data) => apiCall(endpoint, {
-    method: 'PATCH',
-    body: JSON.stringify(data)
-  }),
-  delete: (endpoint) => apiCall(endpoint, { method: 'DELETE' })
-};
+## Deploy
+
+Deploy with the **`xano` CLI** (`npm i -g @xano/cli`, then `xano auth`). A
+**build** is an uploaded snapshot; a **deploy** points an environment (`dev` or
+`prod`, each its own URL) at a build.
+
+```bash
+xano static_host create my-app                              # one-time
+xano static_host build push my-app -d ./static -n "v1.0.0"  # push snapshot
+xano static_host deploy my-app --build_id <id> --env dev    # then --env prod
 ```
 
----
+When `static/` has a `package.json`, **Xano runs your `build` script
+server-side** on push. Changes aren't auto-synced — push a new build to publish.
+Full reference (flags, `build pull`, rollback, git integration):
+`xano_cli_docs(topic='static_host')`.
 
-## Authentication
+**After deploy:** the environment URL can 404 briefly until the build
+propagates — allow a few seconds before treating a deploy as failed. Assets are
+cached by filename, so redeploys can serve stale files to returning visitors;
+version asset URLs (e.g. `app.js?v=2`) when an update must take effect immediately.
 
-### Login
-```javascript
-async function login(email, password) {
-  const { authToken } = await api.post('/auth/login', { email, password });
-  localStorage.setItem('auth_token', authToken);
-  return authToken;
-}
-```
+## Best practices
 
-### Signup
-```javascript
-async function signup(email, password, name) {
-  const { authToken } = await api.post('/auth/signup', {
-    email, password, name
-  });
-  localStorage.setItem('auth_token', authToken);
-  return authToken;
-}
-```
-
-### Logout
-```javascript
-function logout() {
-  localStorage.removeItem('auth_token');
-  window.location.href = '/login.html';
-}
-```
-
-### Get Current User
-```javascript
-async function getCurrentUser() {
-  return api.get('/auth/me');
-}
-```
-
----
-
-## Deployment
-
-Deploy static files to Xano CDN:
-
-```
-invoke upload_static_files_to_xano
-```
-
-The tool will:
-1. Bundle files from `static/`
-2. Upload to Xano CDN
-3. Return hosted URL
-
----
-
-## Best Practices
-
-1. **Get API specs first** - Use `get_xano_api_specifications` before coding
-2. **Centralize API calls** - Single `api.js` file
-3. **Store tokens securely** - localStorage for web, secure storage for mobile
-
----
+- **Never ship secrets** — the bundle is world-readable. The only credential is
+  the user's own auth token in `localStorage`. No API keys or DB credentials in
+  client code, including any `VITE_*` variable (inlined into the bundle).
 
 ## Related Topics
 

--- a/src/xanoscript_docs/frontend.md
+++ b/src/xanoscript_docs/frontend.md
@@ -22,7 +22,7 @@ It also drives typed-client codegen in the starter below.
 ## Two starting points
 
 - **Opinionated starter (recommended for apps)** — clone
-  [`xano-labs/static_template`](https://github.com/xano-labs/static_template) into
+  [`xano-inc/static_template`](https://github.com/xano-inc/static_template) into
   `static/`: a Vite + React + TS SPA with auth and typed API hooks (generated from
   your Swagger) already wired. Point it at your instance (`VITE_XANO_API_BASE` +
   `VITE_XANO_SWAGGER_URL`) and build. It ships its own docs — follow those.
@@ -31,14 +31,14 @@ It also drives typed-client codegen in the starter below.
   in one client module that prefixes a base URL and attaches the auth token:
 
   ```javascript
-  const API_BASE = 'https://your-instance.xano.io/api:group';
+  const API_BASE = "https://your-instance.xano.io/api:group";
 
   async function apiCall(endpoint, options = {}) {
-    const token = localStorage.getItem('auth_token');
+    const token = localStorage.getItem("auth_token");
     const res = await fetch(`${API_BASE}${endpoint}`, {
       ...options,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         ...(token && { Authorization: `Bearer ${token}` }),
         ...options.headers,
       },
@@ -82,8 +82,8 @@ version asset URLs (e.g. `app.js?v=2`) when an update must take effect immediate
 
 ## Related Topics
 
-| Topic | Description |
-|-------|-------------|
-| `apis` | Backend API endpoints |
+| Topic       | Description             |
+| ----------- | ----------------------- |
+| `apis`      | Backend API endpoints   |
 | `workspace` | Workspace configuration |
-| `security` | CORS and authentication |
+| `security`  | CORS and authentication |

--- a/src/xanoscript_docs/tables.md
+++ b/src/xanoscript_docs/tables.md
@@ -323,6 +323,7 @@ table "order" {
 2. **Use `auth = true`** only for the authentication table (typically just `user`)
 3. **Add indexes** for fields used in `db.query` WHERE clauses and JOINs to avoid full table scans
 4. **Add new fields to the bottom of the schema** - When adding new fields to an existing table, append them to the end of the schema block rather than inserting them in the middle. This preserves column ordering consistency and avoids unexpected side effects
+5. **`workspace push` is additive, not declarative** - A partial push (the default) adds and updates schema but makes no destructive changes — it won't drop a column you removed or relax an existing constraint, so local files and the live table can diverge. Use `xano workspace push --sync` for destructive schema changes.
 
 ---
 


### PR DESCRIPTION
Generalized, terse doc improvements for first-time AI agents.

**XanoScript**
- `essentials.md` — validation is **syntax-only**: a `valid` result from `xano_validate_xanoscript` can still fail at runtime, so `validate → push → run`.
- `tables.md` + `cli_docs/workspace` — `workspace push` is **additive, not declarative**: no destructive schema changes by default (won't drop columns or relax constraints); use `--sync`.

**Static hosting / frontend**
- `frontend.md` — rewritten static-hosting guide (API-spec-first, build vs deploy, server-side build, secrets warning), plus two deploy-time notes: the env URL can 404 briefly until a build propagates, and assets are cached by filename so redeploys can serve stale files unless asset URLs are versioned.
- `docs_index.json` — broaden the `frontend` topic description/aliases for discoverability.

Source-only (dist builds at publish). `npm run build` clean, `npm test` 218/218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)